### PR TITLE
feat: Action Editor in Workspace Settings

### DIFF
--- a/packages/ui/actions/src/components/ActionEditor.vue
+++ b/packages/ui/actions/src/components/ActionEditor.vue
@@ -1,0 +1,559 @@
+<script setup lang="ts">
+/**
+ * ActionEditor Component
+ *
+ * Visual editor for configuring actions in the workspace.
+ * Actions map handlers to object types and appear in context menus.
+ */
+
+import { ref, computed, inject, watch, onMounted } from 'tsm:vue'
+import { DataTable, Column, Button, Dialog, InputText, Dropdown, Checkbox, InputNumber } from 'tsm:primevue'
+
+const tsm = inject<any>('tsm')
+const editorConfig = inject<any>('gene.editor.config')
+
+const emit = defineEmits<{
+  'dirty': []
+}>()
+
+// Local action type
+interface ActionDef {
+  actionId: string
+  label: string
+  description: string
+  actionType: string
+  actionScope: string
+  targetTypeUri: string
+  targetScope: string
+  handlerId: string
+  perspectiveIds: string[]
+  enabled: boolean
+  order: number
+  type: 'internal' | 'remote'
+  // Remote fields
+  endpointUrl: string
+  httpMethod: string
+}
+
+// State
+const actions = ref<ActionDef[]>([])
+const selectedAction = ref<ActionDef | null>(null)
+const editDialogVisible = ref(false)
+const editingAction = ref<ActionDef>(createEmpty())
+const isNew = ref(false)
+
+// Dropdown options
+const actionTypeOptions = [
+  { label: 'Query', value: 'QUERY' },
+  { label: 'Validation', value: 'VALIDATION' },
+  { label: 'Transformation', value: 'TRANSFORMATION' },
+  { label: 'Documentation', value: 'DOCUMENTATION' },
+  { label: 'Custom', value: 'CUSTOM' }
+]
+
+const actionScopeOptions = [
+  { label: 'Object (Context Menu)', value: 'OBJECT' },
+  { label: 'Editor (Toolbar)', value: 'EDITOR' },
+  { label: 'Both', value: 'BOTH' }
+]
+
+const targetScopeOptions = [
+  { label: 'Exact Type Only', value: 'TYPE_ONLY' },
+  { label: 'Type and Subtypes', value: 'TYPE_AND_SUBTYPES' }
+]
+
+const typeOptions = [
+  { label: 'Internal (TypeScript Handler)', value: 'internal' },
+  { label: 'Remote (HTTP Endpoint)', value: 'remote' }
+]
+
+const httpMethodOptions = [
+  { label: 'POST', value: 'POST' },
+  { label: 'GET', value: 'GET' },
+  { label: 'PUT', value: 'PUT' }
+]
+
+// Available handlers from InternalExecutor
+const availableHandlers = computed<{ label: string; value: string }[]>(() => {
+  try {
+    const executor = tsm?.getService('gene.action.executor.internal')
+    if (!executor?.getRegisteredHandlerIds) return []
+    return executor.getRegisteredHandlerIds().map((id: string) => ({
+      label: id,
+      value: id
+    }))
+  } catch {
+    return []
+  }
+})
+
+// Load from EditorConfig
+function loadActions() {
+  const config = editorConfig?.editorConfig?.value
+  if (!config) {
+    actions.value = []
+    return
+  }
+
+  const emfActions = config.actions || []
+  actions.value = emfActions.map((a: any) => ({
+    actionId: a.actionId || '',
+    label: a.label || '',
+    description: a.description || '',
+    actionType: a.actionType || 'CUSTOM',
+    actionScope: a.actionScope || 'OBJECT',
+    targetTypeUri: a.targetTypeUri || '',
+    targetScope: a.targetScope || 'TYPE_AND_SUBTYPES',
+    handlerId: a.handlerId || '',
+    perspectiveIds: [...(a.perspectiveIds || [])],
+    enabled: a.enabled !== false,
+    order: a.order ?? 0,
+    type: a.endpointUrl ? 'remote' : 'internal',
+    endpointUrl: a.endpointUrl || '',
+    httpMethod: a.httpMethod || 'POST'
+  }))
+}
+
+onMounted(() => loadActions())
+watch(() => editorConfig?.editorConfig?.value, () => loadActions(), { deep: true })
+
+/**
+ * Get the FennecuiFactory from the EditorConfig's EPackage
+ */
+function getFactory(): any {
+  const config = editorConfig?.editorConfig?.value
+  if (!config) return null
+  const eClass = config.eClass?.()
+  const ePackage = eClass?.getEPackage?.()
+  return ePackage?.getEFactoryInstance?.() || null
+}
+
+// Persist to EditorConfig
+function persistActions() {
+  const config = editorConfig?.editorConfig?.value
+  if (!config) return
+
+  const factory = getFactory()
+  if (!factory) {
+    console.warn('[ActionEditor] Cannot persist: no factory available')
+    return
+  }
+
+  // Create EMF instances
+  const emfActions = actions.value.map(a => {
+    const action = a.type === 'remote'
+      ? factory.createRemoteAction()
+      : factory.createInternalAction()
+
+    // Set common fields via eSet
+    const eClass = action.eClass()
+    const setField = (name: string, value: any) => {
+      if (value === undefined || value === null || value === '') return
+      const feature = eClass.getEStructuralFeature(name)
+      if (feature) action.eSet(feature, value)
+    }
+
+    setField('actionId', a.actionId)
+    setField('label', a.label)
+    setField('description', a.description)
+    setField('actionType', a.actionType)
+    setField('actionScope', a.actionScope)
+    setField('targetTypeUri', a.targetTypeUri)
+    setField('targetScope', a.targetScope)
+    setField('enabled', a.enabled)
+    setField('order', a.order)
+
+    if (a.type === 'internal') {
+      setField('handlerId', a.handlerId)
+    } else {
+      setField('endpointUrl', a.endpointUrl)
+      setField('httpMethod', a.httpMethod)
+    }
+
+    return action
+  })
+
+  config.actions = emfActions
+
+  if (editorConfig?.markDirty) editorConfig.markDirty()
+  emit('dirty')
+
+  // Re-register with ActionRegistry
+  try {
+    const registry = tsm?.getService('gene.action.registry')
+    if (registry) {
+      registry.unregisterBySource('workspace')
+      for (const action of config.actions) {
+        if (action.actionId) {
+          registry.register({ definition: action, source: 'workspace' })
+        }
+      }
+    }
+  } catch { /* optional */ }
+}
+
+// Helpers
+function createEmpty(): ActionDef {
+  return {
+    actionId: '',
+    label: '',
+    description: '',
+    actionType: 'CUSTOM',
+    actionScope: 'OBJECT',
+    targetTypeUri: '',
+    targetScope: 'TYPE_AND_SUBTYPES',
+    handlerId: '',
+    perspectiveIds: [],
+    enabled: true,
+    order: 0,
+    type: 'internal',
+    endpointUrl: '',
+    httpMethod: 'POST'
+  }
+}
+
+function clone(a: ActionDef): ActionDef {
+  return { ...a, perspectiveIds: [...a.perspectiveIds] }
+}
+
+// CRUD
+function onAdd() {
+  editingAction.value = createEmpty()
+  isNew.value = true
+  editDialogVisible.value = true
+}
+
+function onEdit(action: ActionDef) {
+  selectedAction.value = action
+  editingAction.value = clone(action)
+  isNew.value = false
+  editDialogVisible.value = true
+}
+
+function onDelete() {
+  if (!selectedAction.value) return
+  const idx = actions.value.indexOf(selectedAction.value)
+  if (idx >= 0) {
+    actions.value.splice(idx, 1)
+    selectedAction.value = null
+    persistActions()
+  }
+}
+
+function onSave() {
+  if (isNew.value) {
+    actions.value.push(clone(editingAction.value))
+  } else if (selectedAction.value) {
+    const idx = actions.value.indexOf(selectedAction.value)
+    if (idx >= 0) {
+      actions.value.splice(idx, 1, clone(editingAction.value))
+    }
+  }
+  editDialogVisible.value = false
+  selectedAction.value = null
+  persistActions()
+}
+
+function onCancel() {
+  editDialogVisible.value = false
+}
+
+function onToggle(action: ActionDef) {
+  action.enabled = !action.enabled
+  persistActions()
+}
+
+function onRowSelect(event: any) {
+  selectedAction.value = event.data
+}
+
+function onRowDblClick(event: any) {
+  onEdit(event.data)
+}
+</script>
+
+<template>
+  <div class="action-list">
+    <!-- Existing actions -->
+    <div v-for="(action, idx) in actions" :key="action.actionId || idx" class="action-item">
+      <div class="action-info">
+        <div class="action-header">
+          <Checkbox :modelValue="action.enabled" :binary="true" @update:modelValue="() => onToggle(action)" />
+          <span class="action-label">{{ action.label || action.actionId }}</span>
+          <span class="action-badge" :class="'badge-' + action.type">{{ action.type }}</span>
+          <span class="action-scope">{{ action.actionScope }}</span>
+        </div>
+        <div class="action-detail">
+          <span class="action-id">{{ action.actionId }}</span>
+          <span class="action-handler">{{ action.type === 'internal' ? action.handlerId : action.endpointUrl }}</span>
+        </div>
+      </div>
+      <div class="action-buttons">
+        <button class="icon-btn" @click="onEdit(action)" title="Edit"><i class="pi pi-pencil"></i></button>
+        <button class="icon-btn danger" @click="selectedAction = action; onDelete()" title="Delete"><i class="pi pi-trash"></i></button>
+      </div>
+    </div>
+
+    <div v-if="actions.length === 0" class="empty-hint">No actions configured.</div>
+
+    <!-- Add button -->
+    <button class="add-btn" @click="onAdd">
+      <i class="pi pi-plus"></i>
+      <span>Add Action</span>
+    </button>
+  </div>
+
+  <!-- Edit dialog -->
+  <Dialog
+    v-model:visible="editDialogVisible"
+    :header="isNew ? 'New Action' : 'Edit Action'"
+    modal
+    :style="{ width: '36rem' }"
+    :closable="true"
+    class="action-dialog"
+  >
+    <div class="dialog-form">
+      <div class="field-grid">
+        <div class="field">
+          <label>Action ID</label>
+          <InputText v-model="editingAction.actionId" placeholder="e.g. my.export-csv" />
+        </div>
+        <div class="field">
+          <label>Label</label>
+          <InputText v-model="editingAction.label" placeholder="Display name in menu" />
+        </div>
+        <div class="field">
+          <label>Description</label>
+          <InputText v-model="editingAction.description" placeholder="Optional" />
+        </div>
+        <div class="field-row">
+          <div class="field">
+            <label>Scope</label>
+            <Dropdown v-model="editingAction.actionScope" :options="actionScopeOptions" optionLabel="label" optionValue="value" />
+          </div>
+          <div class="field">
+            <label>Type</label>
+            <Dropdown v-model="editingAction.actionType" :options="actionTypeOptions" optionLabel="label" optionValue="value" />
+          </div>
+        </div>
+        <div class="field">
+          <label>Target Type URI</label>
+          <InputText v-model="editingAction.targetTypeUri" placeholder="leer = alle Typen" />
+        </div>
+        <div class="field-row">
+          <div class="field">
+            <label>Target Scope</label>
+            <Dropdown v-model="editingAction.targetScope" :options="targetScopeOptions" optionLabel="label" optionValue="value" />
+          </div>
+          <div class="field">
+            <label>Order</label>
+            <InputNumber v-model="editingAction.order" :min="0" />
+          </div>
+        </div>
+
+        <div class="field-separator"></div>
+
+        <div class="field">
+          <label>Handler Type</label>
+          <Dropdown v-model="editingAction.type" :options="typeOptions" optionLabel="label" optionValue="value" />
+        </div>
+        <div v-if="editingAction.type === 'internal'" class="field">
+          <label>Handler</label>
+          <Dropdown v-model="editingAction.handlerId" :options="availableHandlers" optionLabel="label" optionValue="value" placeholder="Select handler..." editable />
+        </div>
+        <template v-if="editingAction.type === 'remote'">
+          <div class="field">
+            <label>Endpoint URL</label>
+            <InputText v-model="editingAction.endpointUrl" placeholder="https://..." />
+          </div>
+          <div class="field">
+            <label>HTTP Method</label>
+            <Dropdown v-model="editingAction.httpMethod" :options="httpMethodOptions" optionLabel="label" optionValue="value" />
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <template #footer>
+      <button class="dialog-btn" @click="onCancel">Cancel</button>
+      <button class="dialog-btn primary" @click="onSave" :disabled="!editingAction.actionId || !editingAction.label">Save</button>
+    </template>
+  </Dialog>
+</template>
+
+<style scoped>
+.action-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.action-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--surface-ground);
+  border-radius: 8px;
+  border: 1px solid var(--surface-border);
+}
+
+.action-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.action-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.action-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.action-badge {
+  font-size: 0.625rem;
+  padding: 1px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.badge-internal { background: color-mix(in srgb, var(--primary-color) 15%, transparent); color: var(--primary-color); }
+.badge-remote { background: color-mix(in srgb, var(--green-500) 15%, transparent); color: var(--green-500); }
+
+.action-scope {
+  font-size: 0.6875rem;
+  color: var(--text-color-secondary);
+}
+
+.action-detail {
+  display: flex;
+  gap: 12px;
+  margin-top: 2px;
+  padding-left: 28px;
+}
+
+.action-id, .action-handler {
+  font-size: 0.6875rem;
+  font-family: monospace;
+  color: var(--text-color-secondary);
+}
+
+.action-buttons {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  background: transparent;
+  color: var(--text-color-secondary);
+  cursor: pointer;
+  border-radius: 6px;
+  font-size: 0.75rem;
+}
+
+.icon-btn:hover { background: var(--surface-hover); color: var(--text-color); }
+.icon-btn.danger:hover { color: var(--red-500); }
+
+.empty-hint {
+  font-size: 0.8125rem;
+  color: var(--text-color-secondary);
+  font-style: italic;
+  padding: 8px 0;
+}
+
+.add-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 1px dashed var(--surface-border);
+  background: transparent;
+  color: var(--text-color-secondary);
+  cursor: pointer;
+  border-radius: 8px;
+  font-size: 0.8125rem;
+  transition: all 0.15s ease;
+}
+
+.add-btn:hover {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+  background: color-mix(in srgb, var(--primary-color) 5%, transparent);
+}
+
+/* Dialog */
+.dialog-form {
+  padding: 4px 0;
+}
+
+.field-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field label {
+  font-size: 0.7rem;
+  color: var(--text-color-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.field :deep(input), .field :deep(.p-dropdown), .field :deep(.p-inputnumber) {
+  width: 100%;
+}
+
+.field-row {
+  display: flex;
+  gap: 10px;
+}
+
+.field-row .field { flex: 1; }
+
+.field-separator {
+  height: 1px;
+  background: var(--surface-border);
+  margin: 4px 0;
+}
+
+.dialog-btn {
+  padding: 6px 16px;
+  border: 1px solid var(--surface-border);
+  background: var(--surface-card);
+  color: var(--text-color);
+  cursor: pointer;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+}
+
+.dialog-btn:hover { background: var(--surface-hover); }
+
+.dialog-btn.primary {
+  background: var(--primary-color);
+  color: white;
+  border-color: var(--primary-color);
+}
+
+.dialog-btn.primary:hover { opacity: 0.9; }
+.dialog-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+</style>

--- a/packages/ui/actions/src/components/EventMappingEditor.vue
+++ b/packages/ui/actions/src/components/EventMappingEditor.vue
@@ -18,6 +18,10 @@ import type { RegisteredAction } from '../types'
 const tsm = inject<any>('tsm')
 const editorConfig = inject<any>('gene.editor.config')
 
+const emit = defineEmits<{
+  'dirty': []
+}>()
+
 // -------------------------------------------------------------------
 // Local types mirroring EMF EventActionMapping structure
 // -------------------------------------------------------------------
@@ -128,7 +132,7 @@ const availableActions = computed<{ label: string; value: string }[]>(() => {
 // -------------------------------------------------------------------
 
 function loadMappings() {
-  const config = editorConfig?.config?.value
+  const config = editorConfig?.editorConfig?.value
   if (!config) {
     mappings.value = []
     return
@@ -160,14 +164,14 @@ function loadMappings() {
 
 onMounted(() => loadMappings())
 
-watch(() => editorConfig?.config?.value, () => loadMappings(), { deep: true })
+watch(() => editorConfig?.editorConfig?.value, () => loadMappings(), { deep: true })
 
 // -------------------------------------------------------------------
 // Persist mappings back to EditorConfig
 // -------------------------------------------------------------------
 
 function persistMappings() {
-  const config = editorConfig?.config?.value
+  const config = editorConfig?.editorConfig?.value
   if (!config) return
 
   config.eventMappings = mappings.value.map((m) => ({
@@ -191,6 +195,9 @@ function persistMappings() {
       valueExpression: po.valueExpression
     }))
   }))
+
+  if (editorConfig?.markDirty) editorConfig.markDirty()
+  emit('dirty')
 }
 
 // -------------------------------------------------------------------
@@ -340,66 +347,32 @@ function onRowDblClick(event: any) {
 </script>
 
 <template>
-  <div class="event-mapping-editor">
-    <!-- Toolbar -->
-    <div class="mapping-toolbar">
-      <span class="toolbar-title">Event-Action Mappings</span>
-      <div class="toolbar-actions">
-        <Button
-          icon="pi pi-plus"
-          label="Add Mapping"
-          severity="success"
-          size="small"
-          @click="onAddMapping"
-        />
-        <Button
-          icon="pi pi-trash"
-          label="Delete"
-          severity="danger"
-          size="small"
-          :disabled="!selectedMapping"
-          @click="onDeleteSelected"
-        />
+  <div class="mapping-list">
+    <!-- Existing mappings -->
+    <div v-for="(mapping, idx) in mappings" :key="mapping.name || idx" class="mapping-item">
+      <div class="mapping-info">
+        <div class="mapping-header">
+          <Checkbox :modelValue="mapping.enabled" :binary="true" @update:modelValue="() => onToggleEnabled(mapping)" />
+          <span class="mapping-label">{{ mapping.name || '(unnamed)' }}</span>
+          <span class="mapping-badge" :class="'badge-' + mapping.eventType.toLowerCase()">{{ mapping.eventType }}</span>
+        </div>
+        <div class="mapping-detail">
+          <span class="mapping-event">{{ eventSummary(mapping) }}</span>
+          <span class="mapping-actions">{{ mapping.actionRefs.join(', ') || '(none)' }}</span>
+        </div>
+      </div>
+      <div class="mapping-buttons">
+        <button class="icon-btn" @click="onEditMapping(mapping)" title="Edit"><i class="pi pi-pencil"></i></button>
+        <button class="icon-btn danger" @click="selectedMapping = mapping; onDeleteSelected()" title="Delete"><i class="pi pi-trash"></i></button>
       </div>
     </div>
 
-    <!-- Mapping list table -->
-    <DataTable
-      :value="mappings"
-      selectionMode="single"
-      :selection="selectedMapping"
-      dataKey="name"
-      scrollable
-      scrollHeight="flex"
-      class="mapping-table"
-      @row-select="onRowSelect"
-      @row-dblclick="onRowDblClick"
-    >
-      <Column header="Enabled" style="width: 5rem">
-        <template #body="{ data }">
-          <Checkbox
-            :modelValue="data.enabled"
-            :binary="true"
-            @update:modelValue="() => onToggleEnabled(data)"
-          />
-        </template>
-      </Column>
-      <Column field="name" header="Name" sortable />
-      <Column header="Event" sortable>
-        <template #body="{ data }">
-          <span class="event-badge" :class="'event-' + data.eventType.toLowerCase()">
-            {{ data.eventType }}
-          </span>
-          {{ eventSummary(data) }}
-        </template>
-      </Column>
-      <Column header="Actions">
-        <template #body="{ data }">
-          {{ data.actionRefs.join(', ') || '(none)' }}
-        </template>
-      </Column>
-      <Column field="executeMode" header="Mode" style="width: 8rem" />
-    </DataTable>
+    <div v-if="mappings.length === 0" class="empty-hint">No event mappings configured.</div>
+
+    <button class="add-btn" @click="onAddMapping">
+      <i class="pi pi-plus"></i>
+      <span>Add Mapping</span>
+    </button>
 
     <!-- Edit / Create dialog -->
     <Dialog
@@ -580,61 +553,106 @@ function onRowDblClick(event: any) {
 </template>
 
 <style scoped>
-.event-mapping-editor {
+.mapping-list {
   display: flex;
   flex-direction: column;
-  height: 100%;
-  background: var(--surface-ground);
-  color: var(--text-color);
+  gap: 6px;
 }
 
-.mapping-toolbar {
+.mapping-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0.75rem;
-  background: var(--surface-card);
-  border-bottom: 1px solid var(--surface-border);
+  padding: 8px 12px;
+  background: var(--surface-ground);
+  border-radius: 8px;
+  border: 1px solid var(--surface-border);
 }
 
-.toolbar-title {
-  font-weight: 600;
-  font-size: 0.9rem;
-}
+.mapping-info { flex: 1; min-width: 0; }
 
-.toolbar-actions {
+.mapping-header {
   display: flex;
-  gap: 0.5rem;
+  align-items: center;
+  gap: 8px;
 }
 
-.mapping-table {
-  flex: 1;
-  overflow: auto;
-}
-
-.event-badge {
-  display: inline-block;
-  padding: 0.15rem 0.4rem;
-  border-radius: 4px;
-  font-size: 0.75rem;
+.mapping-label {
+  font-size: 0.8125rem;
   font-weight: 600;
-  margin-right: 0.4rem;
+  color: var(--text-color);
+}
+
+.mapping-badge {
+  font-size: 0.625rem;
+  padding: 1px 6px;
+  border-radius: 4px;
   text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.3px;
 }
 
-.event-lifecycle {
-  background: var(--blue-400);
-  color: var(--blue-50);
+.badge-lifecycle { background: color-mix(in srgb, var(--primary-color) 15%, transparent); color: var(--primary-color); }
+.badge-domain { background: color-mix(in srgb, var(--green-500) 15%, transparent); color: var(--green-500); }
+.badge-custom { background: color-mix(in srgb, var(--orange-500) 15%, transparent); color: var(--orange-500); }
+
+.mapping-detail {
+  display: flex;
+  gap: 12px;
+  margin-top: 2px;
+  padding-left: 28px;
 }
 
-.event-domain {
-  background: var(--green-400);
-  color: var(--green-50);
+.mapping-event, .mapping-actions {
+  font-size: 0.6875rem;
+  font-family: monospace;
+  color: var(--text-color-secondary);
 }
 
-.event-custom {
-  background: var(--orange-400);
-  color: var(--orange-50);
+.mapping-buttons { display: flex; gap: 2px; flex-shrink: 0; }
+
+.icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  background: transparent;
+  color: var(--text-color-secondary);
+  cursor: pointer;
+  border-radius: 6px;
+  font-size: 0.75rem;
+}
+
+.icon-btn:hover { background: var(--surface-hover); color: var(--text-color); }
+.icon-btn.danger:hover { color: var(--red-500); }
+
+.empty-hint {
+  font-size: 0.8125rem;
+  color: var(--text-color-secondary);
+  font-style: italic;
+  padding: 8px 0;
+}
+
+.add-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 1px dashed var(--surface-border);
+  background: transparent;
+  color: var(--text-color-secondary);
+  cursor: pointer;
+  border-radius: 8px;
+  font-size: 0.8125rem;
+  transition: all 0.15s ease;
+}
+
+.add-btn:hover {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+  background: color-mix(in srgb, var(--primary-color) 5%, transparent);
 }
 
 /* Dialog form styles */

--- a/packages/ui/actions/src/components/index.ts
+++ b/packages/ui/actions/src/components/index.ts
@@ -1,1 +1,2 @@
 export { default as EventMappingEditor } from './EventMappingEditor.vue'
+export { default as ActionEditor } from './ActionEditor.vue'

--- a/packages/ui/actions/src/index.ts
+++ b/packages/ui/actions/src/index.ts
@@ -17,7 +17,7 @@ import { InternalExecutorImpl } from './InternalExecutor'
 import { RemoteExecutorImpl } from './RemoteExecutor'
 import { EventDispatcherImpl } from './EventDispatcher'
 import { exportXmiHandler, copyUriHandler, copyJsonHandler } from './builtinHandlers'
-import { EventMappingEditor } from './components'
+import { EventMappingEditor, ActionEditor } from './components'
 
 // Re-export types
 export * from './types'
@@ -111,7 +111,10 @@ export async function activate(context: ModuleContext): Promise<void> {
   })
 
   // Register UI components
-  context.services.register('gene.action.components', { EventMappingEditor: markRaw(EventMappingEditor) })
+  context.services.register('gene.action.components', {
+    EventMappingEditor: markRaw(EventMappingEditor),
+    ActionEditor: markRaw(ActionEditor)
+  })
 
   context.log.info('Action System module activated with built-in handlers')
 }

--- a/packages/ui/layout/src/components/WorkspaceSettingsDialog.vue
+++ b/packages/ui/layout/src/components/WorkspaceSettingsDialog.vue
@@ -5,7 +5,7 @@
  * Master-Detail view with categories on the left and settings on the right.
  */
 
-import { computed, ref, shallowRef, watch, onMounted, inject } from 'tsm:vue'
+import { computed, ref, shallowRef, triggerRef, watch, onMounted, onUnmounted, inject } from 'tsm:vue'
 import { Dropdown } from 'tsm:primevue'
 import { DataTable } from 'tsm:primevue'
 import { Column } from 'tsm:primevue'
@@ -35,19 +35,22 @@ const editorConfigService = inject<any>('gene.editor.config', null)
 const workspaceSettings = computed(() => perspective.state.workspaceSettings)
 
 // === Master-Detail Navigation ===
-type SettingsCategory = 'icons' | 'storage' | 'resolvers' | 'events'
+type SettingsCategory = 'icons' | 'actions' | 'events' | 'storage' | 'resolvers'
 
 const categories: { id: SettingsCategory; label: string; icon: string }[] = [
   { id: 'icons', label: 'Icon Mappings', icon: 'pi pi-palette' },
+  { id: 'actions', label: 'Actions', icon: 'pi pi-play' },
   { id: 'events', label: 'Event Mappings', icon: 'pi pi-bolt' },
   { id: 'storage', label: 'Storage', icon: 'pi pi-database' },
   { id: 'resolvers', label: 'Package Resolvers', icon: 'pi pi-link' }
 ]
 
-// Event Mapping Editor component (loaded from TSM)
-const EventMappingEditor = computed(() => {
-  return tsm?.getService('gene.action.components')?.EventMappingEditor || null
+// Action components (loaded from TSM)
+const actionComponents = computed(() => {
+  return tsm?.getService('gene.action.components') || null
 })
+const EventMappingEditor = computed(() => actionComponents.value?.EventMappingEditor || null)
+const ActionEditor = computed(() => actionComponents.value?.ActionEditor || null)
 
 const selectedCategory = ref<SettingsCategory>('icons')
 
@@ -85,7 +88,8 @@ interface EditorConfigService {
 }
 
 function getEditorConfigService(): EditorConfigService | null {
-  return editorConfigService || null
+  // Try inject first, then TSM service (different plugin scopes may have different inject values)
+  return editorConfigService || tsm?.getService('gene.editor.config') || null
 }
 
 const editorConfig = shallowRef<EditorConfigService | null>(null)
@@ -131,13 +135,19 @@ function getFileSystem(): any {
 }
 
 async function handleSave() {
-  if (!editorConfig.value?.workspaceFileEntry?.value) return
+  if (!editorConfig.value?.workspaceFileEntry?.value) {
+    console.warn('[WorkspaceSettings] No workspace file entry, cannot save')
+    return
+  }
 
   saving.value = true
   try {
     const fileSystem = getFileSystem()
+    console.log('[WorkspaceSettings] fileSystem:', !!fileSystem, 'writeTextFile:', !!fileSystem?.writeTextFile)
     if (fileSystem?.writeTextFile) {
       await editorConfig.value.saveToFileSystem(fileSystem.writeTextFile)
+      isDirty.value = false
+      console.log('[WorkspaceSettings] Saved successfully')
     }
   } catch (e) {
     console.error('[WorkspaceSettings] Failed to save:', e)
@@ -309,6 +319,7 @@ function getIconClass(mapping: any): string {
 }
 
 const hasEditorConfig = computed(() => !!editorConfig.value?.initialized?.value)
+// Access dirty ref directly — editorConfigService.dirty is a Vue Ref
 const isDirty = computed(() => !!editorConfig.value?.dirty?.value)
 const canSave = computed(() => !!editorConfig.value?.workspaceFileEntry?.value)
 
@@ -576,6 +587,21 @@ function formatKind(kind: string): string {
               </div>
             </div>
 
+            <!-- Actions -->
+            <div v-if="selectedCategory === 'actions'" class="detail-content">
+              <h3 class="detail-title">Actions</h3>
+              <p class="detail-description">Configure actions that appear in context menus. Map handlers to object types.</p>
+              <component
+                v-if="ActionEditor"
+                :is="ActionEditor"
+                @dirty="triggerRef(editorConfig)"
+              />
+              <div v-else class="empty-state">
+                <i class="pi pi-info-circle"></i>
+                Action System module not loaded.
+              </div>
+            </div>
+
             <!-- Event-Action Mappings -->
             <div v-if="selectedCategory === 'events'" class="detail-content">
               <h3 class="detail-title">Event-Action Mappings</h3>
@@ -583,6 +609,7 @@ function formatKind(kind: string): string {
               <component
                 v-if="EventMappingEditor"
                 :is="EventMappingEditor"
+                @dirty="triggerRef(editorConfig)"
               />
               <div v-else class="empty-state">
                 <i class="pi pi-info-circle"></i>

--- a/test-data/ocl-demo/oclfennec.wsp
+++ b/test-data/ocl-demo/oclfennec.wsp
@@ -2,4 +2,6 @@
 <fennecui:EditorConfig xmlns:xmi="http://www.omg.org/XMI" xmi:version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:fennecui="https://eclipse.org/fennec/ts/generic/ui" name="oclfennec" configFileExtensions="" enabled="true" activeViewId="">
   <modelSources name="dge" location="dge.ecore" resolution="RELATIVE_TO_CONFIG" registerPackages="true" enabled="true"/>
   <instanceSources name="Instances" location="instances/people.xmi" resolution="0" enabled="true"/>
+  <actions xsi:type="fennecui:InternalAction" actionId="Export Person" label="Export this person as XMI" actionType="CUSTOM" actionScope="OBJECT" targetTypeUri="https://dg.de/1.0#//Person" targetScope="TYPE_ONLY" perspectiveIds="" order="0" enabled="true" returnTypes="" handlerId="gene.handler.export-xmi" executionEnvironment="MAIN_THREAD" timeoutMs="30000"/>
+  <actions xsi:type="fennecui:InternalAction" actionId="y" label="y" description="y" actionType="CUSTOM" actionScope="OBJECT" targetTypeUri="https://dg.de/1.0#//Address" targetScope="TYPE_AND_SUBTYPES" perspectiveIds="" order="0" enabled="true" returnTypes="" handlerId="gene.handler.export-xmi" executionEnvironment="MAIN_THREAD" timeoutMs="30000"/>
 </fennecui:EditorConfig>


### PR DESCRIPTION
## Summary
- Neuer **Action Editor** in den Workspace Settings (Zahnrad → Actions)
- Actions konfigurieren: Handler zu Objekttypen zuordnen
- Unterstützt interne (TypeScript Handler) und remote (HTTP Endpoint) Actions
- Actions werden als EMF InternalAction/RemoteAction in der EditorConfig persistiert
- Listet verfügbare Handler aus dem InternalExecutor auf
- Restyling von ActionEditor und EventMappingEditor passend zum Settings-Layout
- Fix: Dirty-State-Propagation über emit + triggerRef
- Fix: EventMappingEditor editorConfig Zugriff

## Test plan
- [ ] Workspace Settings öffnen → "Actions" Tab sichtbar
- [ ] Action anlegen mit Handler-Zuordnung
- [ ] Save-Button wird nach Änderung aktiv
- [ ] Speichern schreibt Actions in die .wsp Datei
- [ ] Action erscheint im Kontextmenü (Rechtsklick auf Objekt)