### PR TITLE
feat: release workflow improvements

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -60,8 +60,9 @@
     <div class="branch-select">
       <label for="branch">Branch:</label>
       <select id="branch"><option>main</option></select>
-      <label style="margin-left: auto;">
-        <input type="checkbox" id="create-release"> GitHub Release erstellen
+      <input type="text" id="release-name" placeholder="Release-Name (z.B. Sprint 42)" style="flex:1; padding:0.4rem 0.6rem; background:var(--bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:0.875rem;">
+      <label>
+        <input type="checkbox" id="create-release"> Release erstellen
       </label>
     </div>
 
@@ -256,6 +257,7 @@
           body: JSON.stringify({
             ref: branchSelect.value,
             inputs: {
+              release_name: document.getElementById('release-name').value.trim(),
               plugins: selected.join(','),
               create_release: String(createReleaseEl.checked)
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - 'v*'
   workflow_dispatch:
     inputs:
+      release_name:
+        description: 'Release-Name (z.B. "Sprint 42", "Demo März")'
+        required: false
+        type: string
       plugins:
         description: 'Komma-separierte Plugin-IDs (leer = release-plugins.json)'
         required: false
@@ -36,9 +40,13 @@ jobs:
       - name: Type check
         run: npx vue-tsc --noEmit
 
-      - name: Resolve plugin list
-        id: plugins
+      - name: Resolve version and plugin list
+        id: meta
         run: |
+          VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('package.json','utf-8')).version)")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
           if [ -n "${{ inputs.plugins }}" ]; then
             PLUGINS="${{ inputs.plugins }}"
           else
@@ -61,7 +69,7 @@ jobs:
 
       - name: Filter plugins
         run: |
-          PLUGIN_LIST="${{ steps.plugins.outputs.plugin_list }}"
+          PLUGIN_LIST="${{ steps.meta.outputs.plugin_list }}"
           BUILT_PLUGINS=$(ls dist/plugins/ | grep -v index.json)
 
           for plugin in $BUILT_PLUGINS; do
@@ -87,7 +95,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gene-release
+          name: gene-${{ steps.meta.outputs.version }}
           path: dist/
           retention-days: 30
 
@@ -96,22 +104,29 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd dist && zip -r ../gene-release.zip . && cd ..
+          VERSION="${{ steps.meta.outputs.version }}"
+          RELEASE_NAME="${{ inputs.release_name }}"
+          TAG="${GITHUB_REF_NAME:-v${VERSION}}"
+          ZIP_NAME="gene-${VERSION}.zip"
 
-          TAG="${GITHUB_REF_NAME:-manual-$(date +%Y%m%d-%H%M%S)}"
+          cd dist && zip -r "../${ZIP_NAME}" . && cd ..
 
           PLUGINS=$(node -e "
             const idx = JSON.parse(require('fs').readFileSync('dist/plugins/index.json','utf-8'));
             idx.modules.forEach(m => console.log('- ' + m));
           ")
 
-          gh release create "$TAG" gene-release.zip \
-            --title "GenE $TAG" \
-            --notes "$(cat <<'NOTES'
-          ## GenE Release
+          if [ -n "$RELEASE_NAME" ]; then
+            TITLE="GenE ${VERSION} — ${RELEASE_NAME}"
+          else
+            TITLE="GenE ${VERSION}"
+          fi
+
+          gh release create "$TAG" "$ZIP_NAME" \
+            --title "$TITLE" \
+            --notes "## GenE Release ${VERSION}
 
           ### Enthaltene Plugins
-          $PLUGINS
-          NOTES
-          )" \
+          ${PLUGINS}
+          " \
             --latest


### PR DESCRIPTION
## Summary
- Artifact name includes version: `gene-0.0.1` instead of `gene-release`
- Zip file includes version: `gene-0.0.1.zip`
- New `release_name` input for custom release titles (e.g. "Sprint 42")
- Release title: `GenE 0.0.1 — Sprint 42` (or just `GenE 0.0.1` without name)
- Fix `$PLUGINS` expansion in release notes (was inside single-quoted heredoc)
- Pages UI: added release name input field