### PR TITLE
fix: release workflow tag and prerelease handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,14 @@ jobs:
             TITLE="GenE ${VERSION}"
           fi
 
+          # Delete existing release with same tag (if re-running)
+          gh release delete "$TAG" --yes 2>/dev/null || true
+
+          PRERELEASE_FLAG=""
+          if [[ "$VERSION" == *-* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
           gh release create "$TAG" "$ZIP_NAME" \
             --title "$TITLE" \
             --notes "## GenE Release ${VERSION}
@@ -133,4 +141,4 @@ jobs:
           ### Enthaltene Plugins
           ${PLUGINS}
           " \
-            --latest
+            $PRERELEASE_FLAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,11 @@ jobs:
         run: |
           VERSION="${{ steps.meta.outputs.version }}"
           RELEASE_NAME="${{ inputs.release_name }}"
-          TAG="${GITHUB_REF_NAME:-v${VERSION}}"
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF_NAME}"
+          else
+            TAG="v${VERSION}"
+          fi
           ZIP_NAME="gene-${VERSION}.zip"
 
           cd dist && zip -r "../${ZIP_NAME}" . && cd ..


### PR DESCRIPTION
## Summary
- Use version-based tag (`v0.0.1-next.1`) for workflow_dispatch releases instead of branch name (`main`)
- Mark versions with `-` suffix (e.g. `next.1`, `alpha.2`) as prerelease
- Delete existing release with same tag before creating (allows re-runs)