### PR TITLE
chore: remove obsolete manifest dependencies

### DIFF
--- a/packages/cocl-editor/manifest.json
+++ b/packages/cocl-editor/manifest.json
@@ -6,8 +6,7 @@
   "entry": "src/index.ts",
   "dependencies": [
     "gene-app",
-    "ui-layout",
-    "transformation"
+    "ui-layout"
   ],
   "provides": [
     {

--- a/packages/dmn-editor/manifest.json
+++ b/packages/dmn-editor/manifest.json
@@ -7,8 +7,7 @@
   "dependencies": [
     "gene-app",
     "ui-layout",
-    "ui-perspectives",
-    "ui-model-browser"
+    "ui-perspectives"
   ],
   "provides": [
     {

--- a/packages/ui-instance-tree/manifest.json
+++ b/packages/ui-instance-tree/manifest.json
@@ -17,7 +17,6 @@
   "dependencies": [
     "gene-app",
     "ui-layout",
-    "ui-perspectives",
-    "ui-model-browser"
+    "ui-perspectives"
   ]
 }

--- a/packages/ui-model-view/manifest.json
+++ b/packages/ui-model-view/manifest.json
@@ -17,7 +17,6 @@
   "dependencies": [
     "gene-app",
     "ui-layout",
-    "ui-perspectives",
-    "instance-builder"
+    "ui-perspectives"
   ]
 }

--- a/packages/ui-properties-panel/manifest.json
+++ b/packages/ui-properties-panel/manifest.json
@@ -12,8 +12,6 @@
   ],
   "dependencies": [
     "gene-app",
-    "ui-layout",
-    "ui-instance-tree",
-    "instance-builder"
+    "ui-layout"
   ]
 }


### PR DESCRIPTION
Remove manifest.json dependencies no longer required after TSM service decoupling:
- cocl-editor: remove transformation
- dmn-editor: remove ui-model-browser
- ui-instance-tree: remove ui-model-browser
- ui-properties-panel: remove ui-instance-tree, instance-builder
- ui-model-view: remove instance-builder

Fixes missing dependency errors in release builds with subset plugin selection.