### PR TITLE
fix: Issue #37 Punkte 4-6 — NS-URI, Instanz-Labels, XMI-ID/Primary-Key

### DIFF
--- a/packages/instance-builder/src/components/AttributeField.vue
+++ b/packages/instance-builder/src/components/AttributeField.vue
@@ -248,7 +248,7 @@ const isRequired = computed(() => {
 }
 
 .required-indicator {
-  color: var(--red-500);
+  color: var(--p-red-500, #ef4444);
   margin-left: 0.25rem;
 }
 
@@ -265,8 +265,15 @@ const isRequired = computed(() => {
 }
 
 .field-error {
-  color: var(--red-500);
+  color: var(--p-red-500, #ef4444);
   font-size: 0.75rem;
+}
+
+:deep(.p-invalid.p-inputtext),
+:deep(.p-invalid.p-select),
+:deep(.p-invalid.p-textarea) {
+  border-color: var(--p-red-500, #ef4444) !important;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--p-red-500, #ef4444) 40%, transparent);
 }
 
 .w-full {

--- a/packages/instance-builder/src/components/ReferenceField.vue
+++ b/packages/instance-builder/src/components/ReferenceField.vue
@@ -743,6 +743,13 @@ const selectedAddOption = computed({
   font-size: 0.75rem;
 }
 
+:deep(.p-invalid.p-inputtext),
+:deep(.p-invalid.p-select),
+:deep(.p-invalid.p-textarea) {
+  border-color: var(--p-red-500, #ef4444) !important;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--p-red-500, #ef4444) 40%, transparent);
+}
+
 /* OCL filter styles */
 .dropdown-option {
   display: flex;

--- a/packages/ui-instance-tree/src/components/InstanceTree.vue
+++ b/packages/ui-instance-tree/src/components/InstanceTree.vue
@@ -755,7 +755,7 @@ watch(ctxSelectedObject, (obj) => {
           >
             <img v-if="node.iconDataUrl" :src="node.iconDataUrl" class="node-icon node-icon--img" alt="" />
             <i v-else-if="node.iconClass" :class="node.iconClass" class="node-icon" />
-            <span class="node-label">{{ node.label }}</span>
+            <span class="node-label" :title="node.xmiId ? `XMI-ID: ${node.xmiId}` : undefined">{{ node.label }}</span>
           </div>
         </template>
       </Tree>

--- a/packages/ui-instance-tree/src/components/ViewsEditorPanel.vue
+++ b/packages/ui-instance-tree/src/components/ViewsEditorPanel.vue
@@ -230,7 +230,7 @@ function ePackageToTreeNode(pkg: EPackage): any {
           key: `class-${nsURI}-${eClass.getName()}`,
           label: eClass.getName(),
           icon: eClass.isAbstract() ? 'pi pi-code' : 'pi pi-box',
-          data: { type: 'class', eClass },
+          data: { type: 'class', eClass, pkgInfo: { nsURI } },
           leaf: true
         })
       }
@@ -593,10 +593,12 @@ function hiddenCount(viewId: string): number {
                     @update:modelValue="toggleClassInView(typeDialogView!.id, node.data.eClass)"
                     binary
                   />
-                  <span class="type-label" :class="{ hidden: isClassHidden(typeDialogView!.id, node.data.eClass) }">
+                  <span class="type-label" :class="{ hidden: isClassHidden(typeDialogView!.id, node.data.eClass) }"
+                    :title="node.key">
                     {{ node.label }}
                   </span>
                   <span v-if="node.data.eClass?.isAbstract?.()" class="abstract-tag">abstract</span>
+                  <span class="ns-uri-label">{{ node.data.pkgInfo?.nsURI || '' }}</span>
                 </template>
                 <template v-else-if="node.data?.type === 'package'">
                   <Checkbox
@@ -605,6 +607,7 @@ function hiddenCount(viewId: string): number {
                     binary
                   />
                   <span class="type-label pkg-label">{{ node.label }}</span>
+                  <span class="ns-uri-label">{{ node.data.pkgInfo?.nsURI || node.data.pkg?.getNsURI?.() || '' }}</span>
                 </template>
               </div>
             </template>
@@ -931,5 +934,16 @@ function hiddenCount(viewId: string): number {
   padding: 1px 4px;
   border-radius: 3px;
   font-style: italic;
+}
+
+.ns-uri-label {
+  font-size: 0.65rem;
+  color: var(--text-color-secondary);
+  opacity: 0.7;
+  margin-left: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
 }
 </style>

--- a/packages/ui-instance-tree/src/composables/useInstanceTree.ts
+++ b/packages/ui-instance-tree/src/composables/useInstanceTree.ts
@@ -311,7 +311,8 @@ export function useInstanceTree(resource: Ref<Resource | null>) {
       eClass,
       leaf: true,
       containmentRef,
-      parent
+      parent,
+      xmiId: getXmiId(rawObj)
     }
 
     // Get containment references and build children

--- a/packages/ui-instance-tree/src/types.ts
+++ b/packages/ui-instance-tree/src/types.ts
@@ -35,6 +35,8 @@ export interface InstanceTreeNode {
   containmentRef?: EReference
   /** Parent node */
   parent?: InstanceTreeNode
+  /** XMI ID (for tooltip) */
+  xmiId?: string | null
 }
 
 /**
@@ -120,7 +122,6 @@ export function getObjectLabel(obj: EObject): string {
   const eClass = obj.eClass()
   const className = getClassName(eClass)
 
-
   // Try common naming attributes
   const nameAttr = eClass.getEStructuralFeature('name')
   if (nameAttr) {
@@ -133,7 +134,7 @@ export function getObjectLabel(obj: EObject): string {
     const eidAttr = eClass.getEIDAttribute()
     if (eidAttr) {
       const eid = obj.eGet(eidAttr)
-      if (eid) return `${className}: ${eid}`
+      if (eid) return `${className} [${eid}]`
     }
   }
 
@@ -141,8 +142,17 @@ export function getObjectLabel(obj: EObject): string {
   const idAttr = eClass.getEStructuralFeature('id')
   if (idAttr) {
     const id = obj.eGet(idAttr)
-    if (id) return `${className}: ${id}`
+    if (id) return `${className} [${id}]`
   }
+
+  // Try XMI ID as fallback
+  try {
+    const resource = obj.eResource?.()
+    if (resource && typeof (resource as any).getID === 'function') {
+      const xmiId = (resource as any).getID(obj)
+      if (xmiId) return `${className} [${xmiId}]`
+    }
+  } catch { /* ignore */ }
 
   // Try first non-empty string attribute as fallback
   if (typeof eClass.getEAllAttributes === 'function') {
@@ -155,7 +165,19 @@ export function getObjectLabel(obj: EObject): string {
     }
   }
 
-  // Fall back to class name only
+  // Fall back to class name with sibling index
+  try {
+    const container = obj.eContainer?.()
+    const feature = obj.eContainingFeature?.()
+    if (container && feature && (feature as any).isMany?.()) {
+      const siblings = container.eGet(feature)
+      if (siblings && typeof siblings.indexOf === 'function') {
+        const idx = siblings.indexOf(obj)
+        if (idx >= 0) return `${className} #${idx + 1}`
+      }
+    }
+  } catch { /* ignore */ }
+
   return className
 }
 

--- a/packages/ui-properties-panel/src/components/PropertiesPanel.vue
+++ b/packages/ui-properties-panel/src/components/PropertiesPanel.vue
@@ -169,6 +169,27 @@ const xmiId = computed(() => {
   return getXmiId(selectedObject.value)
 })
 
+// Primary-Key ID (model-level iD="true" attribute or 'id' attribute)
+const primaryKeyId = computed(() => {
+  if (!selectedObject.value || !currentEClass.value) return null
+  const eClass = currentEClass.value
+  // Try EClass ID attribute (marked with iD="true" in ecore)
+  if (typeof eClass.getEIDAttribute === 'function') {
+    const eidAttr = eClass.getEIDAttribute()
+    if (eidAttr) {
+      const val = selectedObject.value.eGet(eidAttr)
+      if (val) return { name: eidAttr.getName(), value: String(val) }
+    }
+  }
+  // Try 'id' attribute by name
+  const idAttr = eClass.getEStructuralFeature('id')
+  if (idAttr) {
+    const val = selectedObject.value.eGet(idAttr)
+    if (val) return { name: 'id', value: String(val) }
+  }
+  return null
+})
+
 // Editing state for XMI ID
 const editingXmiId = ref(false)
 const editXmiIdValue = ref('')
@@ -577,7 +598,8 @@ function getReferenceType(ref: EReference): EClass | null {
   // Try native getEReferenceType first
   if (typeof ref.getEReferenceType === 'function') {
     try {
-      return ref.getEReferenceType()
+      const result = ref.getEReferenceType()
+      if (result) return result
     } catch {
       // Fall through to alternative
     }
@@ -585,27 +607,96 @@ function getReferenceType(ref: EReference): EClass | null {
   // Fallback: use getEType (more general)
   if (typeof ref.getEType === 'function') {
     const eType = ref.getEType()
-    if (eType && typeof (eType as any).getEAllStructuralFeatures === 'function') {
-      return eType as EClass
-    }
-    // Handle unresolved proxy: resolve via model registry by parsing the proxy URI
-    if (eType && typeof (eType as any).eIsProxy === 'function' && (eType as any).eIsProxy()) {
-      const proxyURI = (eType as any).eProxyURI?.()?.toString?.() || ''
-      const hashIdx = proxyURI.indexOf('#//')
-      if (hashIdx >= 0) {
-        const nsURI = proxyURI.substring(0, hashIdx)
-        const className = proxyURI.substring(hashIdx + 3) // after #//
-        // Look up in model registry
-        const pkg = modelRegistry.allPackages.value.find(p => p.nsURI === nsURI)
-        if (pkg) {
-          const cls = modelRegistry.getAllClasses(pkg).find(c => c.name === className)
-          if (cls?.eClass) {
-            return cls.eClass
+    if (eType) {
+      // Check if it's a proper EClass (native or DynamicEObject with EClass features)
+      if (typeof (eType as any).getEAllStructuralFeatures === 'function') {
+        return eType as EClass
+      }
+      // DynamicEObject EClass: has eClass() that returns Ecore.EClass metaclass
+      // Check by verifying it has EClass-like features via its metaclass
+      try {
+        const metaClass = (eType as any).eClass?.()
+        if (metaClass) {
+          const metaName = metaClass.getName?.()
+          if (metaName === 'EClass') {
+            return eType as EClass
           }
         }
+      } catch { /* ignore */ }
+      // Handle unresolved proxy: resolve via model registry by parsing the proxy URI
+      if (typeof (eType as any).eIsProxy === 'function' && (eType as any).eIsProxy()) {
+        return resolveProxyType(eType)
       }
     }
   }
+  // Last resort: try to resolve via reference name + model registry
+  return resolveTypeByName(ref)
+}
+
+// Resolve proxy EType via model registry
+function resolveProxyType(eType: any): EClass | null {
+  const proxyURI = eType.eProxyURI?.()?.toString?.() || ''
+  // Try #// format: "nsURI#//ClassName"
+  const hashIdx = proxyURI.indexOf('#//')
+  if (hashIdx >= 0) {
+    const nsURI = proxyURI.substring(0, hashIdx)
+    const className = proxyURI.substring(hashIdx + 3)
+    return findClassInRegistry(nsURI, className)
+  }
+  // Try # format: "nsURI#ClassName"
+  const simpleHashIdx = proxyURI.indexOf('#')
+  if (simpleHashIdx >= 0) {
+    const nsURI = proxyURI.substring(0, simpleHashIdx)
+    const className = proxyURI.substring(simpleHashIdx + 1).replace(/^\/\//, '')
+    return findClassInRegistry(nsURI, className)
+  }
+  return null
+}
+
+// Find a class in model registry by nsURI and name
+function findClassInRegistry(nsURI: string, className: string): EClass | null {
+  if (!modelRegistry?.allPackages?.value) return null
+  for (const pkg of modelRegistry.allPackages.value) {
+    if (pkg.nsURI === nsURI) {
+      // Try getAllClasses first (includes abstract)
+      if (modelRegistry.getAllClasses) {
+        const cls = modelRegistry.getAllClasses(pkg).find((c: any) => c.name === className)
+        if (cls?.eClass) return cls.eClass
+      }
+      // Try getConcreteClasses
+      const cls = modelRegistry.getConcreteClasses(pkg).find((c: any) => c.name === className)
+      if (cls?.eClass) return cls.eClass
+      // Try ePackage.getEClassifier
+      const classifier = pkg.ePackage?.getEClassifier?.(className)
+      if (classifier && typeof (classifier as any).getEAllStructuralFeatures === 'function') {
+        return classifier as EClass
+      }
+    }
+  }
+  return null
+}
+
+// Resolve reference type by looking at the reference's name and metadata
+function resolveTypeByName(ref: EReference): EClass | null {
+  try {
+    // DynamicEObject: try to get eType via eGet
+    const refClass = (ref as any).eClass?.()
+    if (refClass) {
+      const eTypeFeature = refClass.getEStructuralFeature?.('eType')
+      if (eTypeFeature) {
+        const eType = (ref as any).eGet?.(eTypeFeature)
+        if (eType) {
+          // Check if it's a proxy
+          if (typeof eType.eIsProxy === 'function' && eType.eIsProxy()) {
+            return resolveProxyType(eType)
+          }
+          // Check if it's a valid EClass
+          const metaName = eType.eClass?.()?.getName?.()
+          if (metaName === 'EClass') return eType as EClass
+        }
+      }
+    }
+  } catch { /* ignore */ }
   return null
 }
 
@@ -952,6 +1043,12 @@ function handleCancelParameterDialog() {
             v-tooltip.bottom="'Generate new UUID'"
           />
         </template>
+      </div>
+
+      <!-- Primary-Key ID (model-level) -->
+      <div v-if="primaryKeyId" class="xmi-id-row">
+        <label class="xmi-id-label">ID ({{ primaryKeyId.name }}):</label>
+        <span class="xmi-id-value">{{ primaryKeyId.value }}</span>
       </div>
 
       <!-- Validation errors -->


### PR DESCRIPTION
## Summary

- **Punkt 4**: NS-URI im Views-Editor sichtbar — Paketknoten zeigen vollständige NS-URI, Klassenknoten haben NS-URI Subtext + Tooltip
- **Punkt 5**: Instanz-Label Fallback mit ID — `ClassName [id]` bei fehlenden Namen, `ClassName #index` als Notnagel
- **Punkt 6**: XMI-ID und Primary-Key-ID separat im Properties Panel, XMI-ID als Tooltip auf Tree-Knoten
- Validierungs-Highlighting für required-Felder im Dark Theme sichtbar (roter Rahmen)

Closes #37 (Punkte 4, 5, 6)

## Test plan

- [ ] Views-Editor: Paket- und Klassenknoten zeigen NS-URI
- [ ] Instanzen ohne Name zeigen `ClassName [id]` oder `ClassName #index`
- [ ] Properties Panel: Primary-Key-ID als eigene Zeile unter XMI-ID
- [ ] Required-Felder ohne Wert haben roten Rahmen + Fehlertext