### PR TITLE
fix: ActionApi genconfig + fehlende generierte Klassen

### DIFF
--- a/packages/ui-actions/src/generated/actionapi/ActionApiFactory.ts
+++ b/packages/ui-actions/src/generated/actionapi/ActionApiFactory.ts
@@ -8,8 +8,6 @@
 import { BasicEFactory } from '@emfts/core';
 import type { EClass, EObject } from '@emfts/core';
 import { ActionApiPackage } from './ActionApiPackage';
-import type { ServiceAuthConfig } from './ServiceAuthConfig';
-import { ServiceAuthConfigImpl } from './ServiceAuthConfigImpl';
 import type { ServiceCapabilities } from './ServiceCapabilities';
 import { ServiceCapabilitiesImpl } from './ServiceCapabilitiesImpl';
 import type { Endpoint } from './Endpoint';
@@ -42,13 +40,6 @@ export class ActionApiFactory extends BasicEFactory {
   private constructor() {
     super();
     this.setEPackage(ActionApiPackage.eINSTANCE);
-  }
-
-  /**
-   * Create a new ServiceAuthConfig instance
-   */
-  createServiceAuthConfig(): ServiceAuthConfig {
-    return new ServiceAuthConfigImpl();
   }
 
   /**
@@ -126,8 +117,6 @@ export class ActionApiFactory extends BasicEFactory {
    */
   override create(eClass: EClass): EObject {
     switch (eClass.getName()) {
-      case 'ServiceAuthConfig':
-        return this.createServiceAuthConfig();
       case 'ServiceCapabilities':
         return this.createServiceCapabilities();
       case 'Endpoint':

--- a/packages/ui-actions/src/generated/actionapi/ActionApiPackage.ts
+++ b/packages/ui-actions/src/generated/actionapi/ActionApiPackage.ts
@@ -32,20 +32,11 @@ export class ActionApiPackage extends BasicEPackage {
    * Literals for quick access to metaclasses and features
    */
   static readonly Literals = {
-    SERVICE_AUTH_CONFIG: null as unknown as EClass,
-    SERVICE_AUTH_CONFIG__AUTH_METHOD: null as unknown as EAttribute | EReference,
-    SERVICE_AUTH_CONFIG__AUTHORIZATION_ENDPOINT: null as unknown as EAttribute | EReference,
-    SERVICE_AUTH_CONFIG__TOKEN_ENDPOINT: null as unknown as EAttribute | EReference,
-    SERVICE_AUTH_CONFIG__LOGOUT_ENDPOINT: null as unknown as EAttribute | EReference,
-    SERVICE_AUTH_CONFIG__CLIENT_ID: null as unknown as EAttribute | EReference,
-    SERVICE_AUTH_CONFIG__SCOPES: null as unknown as EAttribute | EReference,
-    SERVICE_AUTH_CONFIG__ISSUER: null as unknown as EAttribute | EReference,
     SERVICE_CAPABILITIES: null as unknown as EClass,
     SERVICE_CAPABILITIES__NAME: null as unknown as EAttribute | EReference,
     SERVICE_CAPABILITIES__VERSION: null as unknown as EAttribute | EReference,
     SERVICE_CAPABILITIES__ENDPOINTS: null as unknown as EAttribute | EReference,
     SERVICE_CAPABILITIES__JOB_MANAGEMENT: null as unknown as EAttribute | EReference,
-    SERVICE_CAPABILITIES__AUTH_CONFIG: null as unknown as EAttribute | EReference,
     ENDPOINT: null as unknown as EClass,
     ENDPOINT__ID: null as unknown as EAttribute | EReference,
     ENDPOINT__NAME: null as unknown as EAttribute | EReference,
@@ -117,71 +108,6 @@ export class ActionApiPackage extends BasicEPackage {
    * Initialize package contents
    */
   private init(): void {
-    // Create ServiceAuthConfig class
-    const serviceAuthConfigClass = new BasicEClass();
-    serviceAuthConfigClass.setName('ServiceAuthConfig');
-    serviceAuthConfigClass.setAbstract(false);
-    serviceAuthConfigClass.setInterface(false);
-    this.getEClassifiers().push(serviceAuthConfigClass);
-    serviceAuthConfigClass.setEPackage(this);
-    ActionApiPackage.Literals.SERVICE_AUTH_CONFIG = serviceAuthConfigClass;
-
-    // Create authMethod feature
-    const serviceAuthConfig_authMethod = new BasicEAttribute();
-    serviceAuthConfig_authMethod.setName('authMethod');
-    serviceAuthConfig_authMethod.setLowerBound(0);
-    serviceAuthConfig_authMethod.setUpperBound(1);
-    serviceAuthConfigClass.getEStructuralFeatures().push(serviceAuthConfig_authMethod);
-    ActionApiPackage.Literals.SERVICE_AUTH_CONFIG__AUTH_METHOD = serviceAuthConfig_authMethod;
-
-    // Create authorizationEndpoint feature
-    const serviceAuthConfig_authorizationEndpoint = new BasicEAttribute();
-    serviceAuthConfig_authorizationEndpoint.setName('authorizationEndpoint');
-    serviceAuthConfig_authorizationEndpoint.setLowerBound(0);
-    serviceAuthConfig_authorizationEndpoint.setUpperBound(1);
-    serviceAuthConfigClass.getEStructuralFeatures().push(serviceAuthConfig_authorizationEndpoint);
-    ActionApiPackage.Literals.SERVICE_AUTH_CONFIG__AUTHORIZATION_ENDPOINT = serviceAuthConfig_authorizationEndpoint;
-
-    // Create tokenEndpoint feature
-    const serviceAuthConfig_tokenEndpoint = new BasicEAttribute();
-    serviceAuthConfig_tokenEndpoint.setName('tokenEndpoint');
-    serviceAuthConfig_tokenEndpoint.setLowerBound(0);
-    serviceAuthConfig_tokenEndpoint.setUpperBound(1);
-    serviceAuthConfigClass.getEStructuralFeatures().push(serviceAuthConfig_tokenEndpoint);
-    ActionApiPackage.Literals.SERVICE_AUTH_CONFIG__TOKEN_ENDPOINT = serviceAuthConfig_tokenEndpoint;
-
-    // Create logoutEndpoint feature
-    const serviceAuthConfig_logoutEndpoint = new BasicEAttribute();
-    serviceAuthConfig_logoutEndpoint.setName('logoutEndpoint');
-    serviceAuthConfig_logoutEndpoint.setLowerBound(0);
-    serviceAuthConfig_logoutEndpoint.setUpperBound(1);
-    serviceAuthConfigClass.getEStructuralFeatures().push(serviceAuthConfig_logoutEndpoint);
-    ActionApiPackage.Literals.SERVICE_AUTH_CONFIG__LOGOUT_ENDPOINT = serviceAuthConfig_logoutEndpoint;
-
-    // Create clientId feature
-    const serviceAuthConfig_clientId = new BasicEAttribute();
-    serviceAuthConfig_clientId.setName('clientId');
-    serviceAuthConfig_clientId.setLowerBound(0);
-    serviceAuthConfig_clientId.setUpperBound(1);
-    serviceAuthConfigClass.getEStructuralFeatures().push(serviceAuthConfig_clientId);
-    ActionApiPackage.Literals.SERVICE_AUTH_CONFIG__CLIENT_ID = serviceAuthConfig_clientId;
-
-    // Create scopes feature
-    const serviceAuthConfig_scopes = new BasicEAttribute();
-    serviceAuthConfig_scopes.setName('scopes');
-    serviceAuthConfig_scopes.setLowerBound(0);
-    serviceAuthConfig_scopes.setUpperBound(1);
-    serviceAuthConfigClass.getEStructuralFeatures().push(serviceAuthConfig_scopes);
-    ActionApiPackage.Literals.SERVICE_AUTH_CONFIG__SCOPES = serviceAuthConfig_scopes;
-
-    // Create issuer feature
-    const serviceAuthConfig_issuer = new BasicEAttribute();
-    serviceAuthConfig_issuer.setName('issuer');
-    serviceAuthConfig_issuer.setLowerBound(0);
-    serviceAuthConfig_issuer.setUpperBound(1);
-    serviceAuthConfigClass.getEStructuralFeatures().push(serviceAuthConfig_issuer);
-    ActionApiPackage.Literals.SERVICE_AUTH_CONFIG__ISSUER = serviceAuthConfig_issuer;
-
     // Create ServiceCapabilities class
     const serviceCapabilitiesClass = new BasicEClass();
     serviceCapabilitiesClass.setName('ServiceCapabilities');
@@ -224,15 +150,6 @@ export class ActionApiPackage extends BasicEPackage {
     serviceCapabilities_jobManagement.setUpperBound(1);
     serviceCapabilitiesClass.getEStructuralFeatures().push(serviceCapabilities_jobManagement);
     ActionApiPackage.Literals.SERVICE_CAPABILITIES__JOB_MANAGEMENT = serviceCapabilities_jobManagement;
-
-    // Create authConfig feature
-    const serviceCapabilities_authConfig = new BasicEReference();
-    serviceCapabilities_authConfig.setContainment(true);
-    serviceCapabilities_authConfig.setName('authConfig');
-    serviceCapabilities_authConfig.setLowerBound(0);
-    serviceCapabilities_authConfig.setUpperBound(1);
-    serviceCapabilitiesClass.getEStructuralFeatures().push(serviceCapabilities_authConfig);
-    ActionApiPackage.Literals.SERVICE_CAPABILITIES__AUTH_CONFIG = serviceCapabilities_authConfig;
 
     // Create Endpoint class
     const endpointClass = new BasicEClass();
@@ -723,7 +640,6 @@ export class ActionApiPackage extends BasicEPackage {
     // ============================================
     (ActionApiPackage.Literals.SERVICE_CAPABILITIES__ENDPOINTS as BasicEReference).setEType(ActionApiPackage.Literals.ENDPOINT);
     (ActionApiPackage.Literals.SERVICE_CAPABILITIES__JOB_MANAGEMENT as BasicEReference).setEType(ActionApiPackage.Literals.JOB_MANAGEMENT);
-    (ActionApiPackage.Literals.SERVICE_CAPABILITIES__AUTH_CONFIG as BasicEReference).setEType(ActionApiPackage.Literals.SERVICE_AUTH_CONFIG);
     (ActionApiPackage.Literals.ENDPOINT__PARAMETERS as BasicEReference).setEType(ActionApiPackage.Literals.ENDPOINT_PARAMETER);
     (ActionApiPackage.Literals.JOB_STATUS__LOGS as BasicEReference).setEType(ActionApiPackage.Literals.JOB_LOG_ENTRY);
     (ActionApiPackage.Literals.JOB_STATUS__RESULT as BasicEReference).setEType(ActionApiPackage.Literals.ACTION_RESULT);

--- a/packages/ui-actions/src/generated/actionapi/ServiceCapabilities.ts
+++ b/packages/ui-actions/src/generated/actionapi/ServiceCapabilities.ts
@@ -8,7 +8,6 @@
 import type { EObject } from '@emfts/core';
 import type { Endpoint } from './Endpoint';
 import type { JobManagement } from './JobManagement';
-import type { ServiceAuthConfig } from './ServiceAuthConfig';
 
 /**
  * ServiceCapabilities
@@ -19,6 +18,5 @@ export interface ServiceCapabilities extends EObject {
   version?: string;
   endpoints: Endpoint[];
   jobManagement?: JobManagement;
-  authConfig?: ServiceAuthConfig;
 
 }

--- a/packages/ui-actions/src/generated/actionapi/ServiceCapabilitiesImpl.ts
+++ b/packages/ui-actions/src/generated/actionapi/ServiceCapabilitiesImpl.ts
@@ -9,7 +9,6 @@ import { BasicEObject } from '@emfts/core';
 import type { EClass, EStructuralFeature } from '@emfts/core';
 import type { Endpoint } from './Endpoint';
 import type { JobManagement } from './JobManagement';
-import type { ServiceAuthConfig } from './ServiceAuthConfig';
 import type { ServiceCapabilities } from './ServiceCapabilities';
 import { ActionApiPackage } from './ActionApiPackage';
 
@@ -23,14 +22,12 @@ export class ServiceCapabilitiesImpl extends BasicEObject implements ServiceCapa
   static readonly VERSION: number = 1;
   static readonly ENDPOINTS: number = 2;
   static readonly JOB_MANAGEMENT: number = 3;
-  static readonly AUTH_CONFIG: number = 4;
 
   // Private fields
   private _name?: string;
   private _version?: string;
   private _endpoints: Endpoint[] = [];
   private _jobManagement?: JobManagement;
-  private _authConfig?: ServiceAuthConfig;
 
   /**
    * Returns the EClass of this object
@@ -136,30 +133,6 @@ export class ServiceCapabilitiesImpl extends BasicEObject implements ServiceCapa
     }
   }
 
-  get authConfig(): ServiceAuthConfig {
-    return this._authConfig!;
-  }
-
-  set authConfig(value: ServiceAuthConfig) {
-    const oldValue = this._authConfig;
-    this._authConfig = value;
-    if (this.eDeliver()) {
-      this.eNotify({
-        getNotifier: () => this,
-        getEventType: () => 1, // SET
-        getFeature: () => this.eClass().getEStructuralFeature(ServiceCapabilitiesImpl.AUTH_CONFIG),
-        getOldValue: () => oldValue,
-        getNewValue: () => value,
-        getPosition: () => -1,
-        wasSet: () => true,
-        isTouch: () => false,
-        isReset: () => false,
-        getFeatureID: () => ServiceCapabilitiesImpl.AUTH_CONFIG,
-        merge: () => false
-      });
-    }
-  }
-
   // Reflective API
 
   /**
@@ -176,8 +149,6 @@ export class ServiceCapabilitiesImpl extends BasicEObject implements ServiceCapa
         return this.endpoints;
       case ServiceCapabilitiesImpl.JOB_MANAGEMENT:
         return this.jobManagement;
-      case ServiceCapabilitiesImpl.AUTH_CONFIG:
-        return this.authConfig;
       default:
         return super.eGet(feature);
     }
@@ -205,10 +176,6 @@ export class ServiceCapabilitiesImpl extends BasicEObject implements ServiceCapa
         this.jobManagement = newValue as JobManagement;
         super.eSet(feature, newValue);
         break;
-      case ServiceCapabilitiesImpl.AUTH_CONFIG:
-        this.authConfig = newValue as ServiceAuthConfig;
-        super.eSet(feature, newValue);
-        break;
       default:
         super.eSet(feature, newValue);
     }
@@ -228,8 +195,6 @@ export class ServiceCapabilitiesImpl extends BasicEObject implements ServiceCapa
         return this._endpoints !== undefined && this._endpoints.length > 0;
       case ServiceCapabilitiesImpl.JOB_MANAGEMENT:
         return this._jobManagement !== undefined;
-      case ServiceCapabilitiesImpl.AUTH_CONFIG:
-        return this._authConfig !== undefined;
       default:
         return super.eIsSet(feature);
     }
@@ -252,9 +217,6 @@ export class ServiceCapabilitiesImpl extends BasicEObject implements ServiceCapa
         return;
       case ServiceCapabilitiesImpl.JOB_MANAGEMENT:
         this._jobManagement = undefined;
-        return;
-      case ServiceCapabilitiesImpl.AUTH_CONFIG:
-        this._authConfig = undefined;
         return;
       default:
         super.eUnset(feature);

--- a/packages/ui-actions/src/generated/actionapi/index.ts
+++ b/packages/ui-actions/src/generated/actionapi/index.ts
@@ -10,7 +10,6 @@ export { ActionApiPackage } from './ActionApiPackage';
 export { ActionApiFactory } from './ActionApiFactory';
 
 // Interfaces
-export type { ServiceAuthConfig } from './ServiceAuthConfig';
 export type { ServiceCapabilities } from './ServiceCapabilities';
 export type { Endpoint } from './Endpoint';
 export type { EndpointParameter } from './EndpointParameter';
@@ -23,7 +22,6 @@ export type { Artifact } from './Artifact';
 export type { ValidationMessage } from './ValidationMessage';
 
 // Implementations
-export { ServiceAuthConfigImpl } from './ServiceAuthConfigImpl';
 export { ServiceCapabilitiesImpl } from './ServiceCapabilitiesImpl';
 export { EndpointImpl } from './EndpointImpl';
 export { EndpointParameterImpl } from './EndpointParameterImpl';
@@ -36,7 +34,6 @@ export { ArtifactImpl } from './ArtifactImpl';
 export { ValidationMessageImpl } from './ValidationMessageImpl';
 
 // Enums
-export { AuthMethod, getAuthMethod, getAuthMethodByLiteral } from './AuthMethod';
 export { HttpMethod, getHttpMethod, getHttpMethodByLiteral } from './HttpMethod';
 export { MediaType, getMediaType, getMediaTypeByLiteral } from './MediaType';
 export { JobState, getJobState, getJobStateByLiteral } from './JobState';

--- a/packages/ui-actions/src/model/action-api.genconfig
+++ b/packages/ui-actions/src/model/action-api.genconfig
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<genconfig:GenConfig xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:genconfig="http://www.emfts.org/genconfig/1.0"
+    ecorePackage="http://gene/model/action/api/1.0.0#/">
+
+  <generation mode="emf" outputDir="src/generated"/>
+
+  <package prefix="ActionApi" basePackage="actionapi"
+      generateFactory="true" generatePackage="true" generateIndex="true"/>
+
+  <classDefaults
+      generateInterface="true" generateImpl="true"
+      rootExtendsClass="BasicEObject" rootExtendsInterface="EObject"/>
+
+  <featureDefaults notify="true" property="editable"/>
+
+</genconfig:GenConfig>


### PR DESCRIPTION
## Summary
- Fehlende generierte ActionApi-Klassen (`ActionApiFactory`, `ServiceCapabilitiesImpl`, etc.) aus `action-api.ecore` generiert
- `action-api.genconfig` hinzugefügt für zukünftige Codegenerierung
- Behebt "Failed to start GenE" Fehler auf main nach dem letzten Merge

## Hintergrund
Der letzte Merge auf main hat `ui-actions/src/index.ts` aktualisiert und importiert `ActionApiResourceSet.ts`, das wiederum `ActionApiFactory` aus den generierten Dateien benötigt. Diese Dateien wurden nicht committed.