### PR TITLE
fix: Production-Build startet nicht (Vite 5→6 Regression)

### DIFF
--- a/packages/storage-core/vite.tsm.config.ts
+++ b/packages/storage-core/vite.tsm.config.ts
@@ -6,8 +6,12 @@
  */
 import { defineConfig } from 'vite'
 import { resolve } from 'path'
+import { tsmPlugin } from '@eclipse-daanse/tsm/vite'
 
 export default defineConfig({
+  plugins: [
+    tsmPlugin({ sharedModules: ['@eclipse-daanse/tsm'] })
+  ],
   build: {
     target: 'esnext',
     minify: false,

--- a/packages/tsm.shared.ts
+++ b/packages/tsm.shared.ts
@@ -1,0 +1,38 @@
+/**
+ * TSM Shared Modules Configuration
+ *
+ * Defines which modules are shared between plugins.
+ * Imports of these modules are rewritten to URLs so the browser caches them.
+ */
+
+// Shared modules - these are loaded once and shared via browser ES module cache
+export const sharedModules = [
+  'storage-core',
+  'storage-model',
+] as const
+
+// Map module names to their plugin URLs
+export const sharedModulePaths: Record<string, string> = {
+  'storage-core': '/plugins/@storage/core/index.js',
+  'storage-model': '/plugins/@storage/model/index.js',
+}
+
+// For dev mode - map to source files (Vite transforms them)
+export const sharedModulePathsDev: Record<string, string> = {
+  'storage-core': '/packages/storage/core/src/index.ts',
+  'storage-model': '/packages/storage/model/src/generated/storage/index.ts',
+}
+
+/**
+ * Get Rollup external config for shared modules
+ */
+export function getExternals(): string[] {
+  return [...sharedModules]
+}
+
+/**
+ * Get Rollup output.paths config for production builds
+ */
+export function getOutputPaths(): Record<string, string> {
+  return { ...sharedModulePaths }
+}

--- a/packages/ui-actions/src/builtinHandlers.ts
+++ b/packages/ui-actions/src/builtinHandlers.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ActionHandler, HandlerContext, ActionResult } from './types'
+import { XMIResource } from '@emfts/core'
 
 /** Export selected object as XMI string */
 export const exportXmiHandler: ActionHandler = {
@@ -14,7 +15,6 @@ export const exportXmiHandler: ActionHandler = {
 
     try {
       // Use emfts serializer
-      const { XMIResource } = await import('@emfts/core')
       const resource = new XMIResource()
       resource.getContents().push(obj)
       const xmiContent = resource.saveToString()

--- a/packages/ui-actions/src/index.ts
+++ b/packages/ui-actions/src/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ModuleContext } from '@eclipse-daanse/tsm'
+import { EPackageRegistry } from '@emfts/core'
 import { markRaw, watch, defineComponent, h, computed } from 'tsm:vue'
 import { ActionRegistryImpl } from './ActionRegistry'
 import { ActionManagerImpl } from './ActionManager'
@@ -58,8 +59,7 @@ export async function activate(context: ModuleContext): Promise<void> {
   // Register EPackages for XMI parsing
   initActionApiPackage()
   // Register ActionsPluginConfig EPackage so xsi:type resolves in config.xmi
-  const { EPackageRegistry } = await import('@emfts/core')
-  EPackageRegistry.INSTANCE.set(ActionsPluginPackage.eNS_URI, ActionsPluginPackage.eINSTANCE)
+EPackageRegistry.INSTANCE.set(ActionsPluginPackage.eNS_URI, ActionsPluginPackage.eINSTANCE)
 
   // Bind core services via DI
   context.services.bindClass('gene.action.registry', ActionRegistryImpl)


### PR DESCRIPTION
## Problem
Nach dem Vite 5→6 Upgrade via Dependabot startete die Production-App nicht mehr mit:
- `Class 'StorageAdapterRegistry' is not decorated with @injectable()`
- `Failed to resolve module specifier '@emfts/core'`

## Ursache
**Vite 6/7 änderte das ESM-Bundle-Verhalten:** `@eclipse-daanse/tsm` wurde in `storage-core` vollständig eingebundelt statt externalisiert. Das erzeugte zwei Symbol-Instanzen für `INJECTABLE_KEY` — eine im Main-Bundle, eine in storage-core — wodurch `isInjectable()` immer `false` zurückgab.

Außerdem wurden dynamische `import('@emfts/core')` in `ui-actions` nicht durch den `tsmPlugin` transformiert und konnten im Browser nicht aufgelöst werden.

## Fix
- `storage-core/vite.tsm.config.ts`: `tsmPlugin` ergänzt → `@eclipse-daanse/tsm` wird korrekt externalisiert, nur eine Symbol-Instanz
- `ui-actions/builtinHandlers.ts` + `index.ts`: Dynamische `import('@emfts/core')` → statische Imports (werden vom tsmPlugin korrekt transformiert)