### PR TITLE
fix: Production-Build (Vite 6) + Metamodeler/Transformation-Fixes → main

### DIFF
--- a/packages/gene-app/src/App.vue
+++ b/packages/gene-app/src/App.vue
@@ -1069,6 +1069,14 @@ async function handleModelAdd(entry: any, content: string) {
 async function handleMetamodelEdit(entry: any, content: string) {
   console.log('[App] Opening metamodel in editor:', entry.name)
 
+  // Composables are otherwise only fetched lazily when the Metamodeler perspective
+  // is first activated (setupMetamodelerPerspective). Editing a model happens before
+  // that switch, so fetch on demand here instead of bailing on first use.
+  if (!metamodelerComposables.value) {
+    const mmc = tsm.getService<any>('ui.metamodeler.composables')
+    if (mmc) metamodelerComposables.value = mmc
+  }
+
   if (!metamodelerComposables.value?.useSharedMetamodeler) {
     console.warn('[App] Metamodeler composables not available')
     return

--- a/packages/metamodeler/manifest.json
+++ b/packages/metamodeler/manifest.json
@@ -7,7 +7,8 @@
   "dependencies": [
     "gene-app",
     "ui-layout",
-    "ui-actions"
+    "ui-actions",
+    "ui-model-browser"
   ],
   "provides": [
     {

--- a/packages/metamodeler/src/components/MetamodelerTree.vue
+++ b/packages/metamodeler/src/components/MetamodelerTree.vue
@@ -6,7 +6,7 @@
  * Displays EPackage, EClass, EAttribute, EReference, and OCL constraints.
  */
 
-import { ref, computed, watch, inject, onMounted, onUnmounted } from 'tsm:vue'
+import { ref, computed, watch, inject, onMounted, onUnmounted, shallowRef } from 'tsm:vue'
 import { Tree } from 'tsm:primevue'
 import type { TreeNode } from 'tsm:primevue'
 import { Button } from 'tsm:primevue'
@@ -102,20 +102,54 @@ const newReferenceName = ref('')
 const newReferenceContainment = ref(false)
 const newReferenceTargetType = ref<EClass | null>(null)
 
-// Available classes for reference target type
-const availableClasses = computed<EClass[]>(() => {
-  const pkg = metamodeler.rootPackage.value
-  if (!pkg) return []
+// Reference target type is chosen via the shared ClassPickerDialog. Resolved from
+// the TSM service registry (ui-model-browser is a manifest dependency, so it is
+// activated first) rather than a static import, to keep plugin modularity intact.
+const showReferenceClassPicker = ref(false)
+const ClassPickerDialog = shallowRef<any>(
+  tsm?.getService?.('ui.model-browser.components')?.ClassPickerDialog ?? null
+)
 
-  const classes: EClass[] = []
-  const classifiers = pkg.getEClassifiers()
-  for (const classifier of classifiers) {
-    if ('isAbstract' in classifier && 'isInterface' in classifier) {
-      classes.push(classifier as EClass)
-    }
-  }
-  return classes
+// Feed the picker our LIVE model (not the shared ModelRegistry, which is a stale
+// separate load) so classes added/edited in this session are selectable.
+// rootPackage keeps the same EPackage instance across edits, so Vue would not
+// notify dependents on mutation — depend on `version` (bumped on every change)
+// to force the picker to re-read newly added classes.
+const metamodelerRootPackages = computed(() => {
+  void metamodeler.version.value
+  return metamodeler.rootPackage.value ? [metamodeler.rootPackage.value] : []
 })
+
+/**
+ * The picker emits an EClass instance from the shared ModelRegistry, which is a
+ * separate load from the metamodel currently being edited here. Map the selection
+ * back to this model's own instance (by package nsURI + class name) so the new
+ * reference's eType points into the edited resource. Fall back to the registry
+ * instance for classes that genuinely live in an external package.
+ */
+function resolveLocalClass(packageNsURI: string, className: string): EClass | null {
+  const root = metamodeler.rootPackage.value
+  if (!root) return null
+  let byName: EClass | null = null
+  let byNsAndName: EClass | null = null
+  const walk = (pkg: EPackage) => {
+    const nsMatch = pkg.getNsURI?.() === packageNsURI
+    for (const c of pkg.getEClassifiers()) {
+      if (c.getName?.() !== className) continue
+      if (!('isAbstract' in c && 'isInterface' in c)) continue
+      byName = byName ?? (c as EClass)
+      if (nsMatch) byNsAndName = c as EClass
+    }
+    for (const sub of pkg.getESubpackages()) walk(sub)
+  }
+  walk(root)
+  return byNsAndName ?? byName
+}
+
+function handleReferenceTargetSelect(selection: { eClass: any; className: string; packageNsURI: string }) {
+  newReferenceTargetType.value = resolveLocalClass(selection.packageNsURI, selection.className) ?? selection.eClass
+  showReferenceClassPicker.value = false
+}
 
 // Context menu items based on selected node type
 const contextMenuItems = computed(() => {
@@ -595,22 +629,17 @@ async function exportJsonSchema() {
         </div>
         <div class="field">
           <label for="refTargetType">Target Type</label>
-          <Select
-            id="refTargetType"
-            v-model="newReferenceTargetType"
-            :options="availableClasses"
-            optionLabel="getName"
-            placeholder="Select target class"
-            class="w-full"
-          >
-            <template #value="slotProps">
-              <span v-if="slotProps.value">{{ slotProps.value.getName() }}</span>
-              <span v-else>{{ slotProps.placeholder }}</span>
-            </template>
-            <template #option="slotProps">
-              {{ slotProps.option.getName() }}
-            </template>
-          </Select>
+          <div class="target-type-picker">
+            <span class="target-type-value" :class="{ placeholder: !newReferenceTargetType }">
+              {{ newReferenceTargetType ? newReferenceTargetType.getName() : 'No class selected' }}
+            </span>
+            <Button
+              label="Select…"
+              size="small"
+              severity="secondary"
+              @click="showReferenceClassPicker = true"
+            />
+          </div>
         </div>
         <div class="field-checkbox">
           <Checkbox v-model="newReferenceContainment" inputId="refContainment" :binary="true" />
@@ -622,6 +651,16 @@ async function exportJsonSchema() {
         <Button label="Create" @click="createNewReference" :disabled="!newReferenceName || !newReferenceTargetType" />
       </template>
     </Dialog>
+
+    <!-- Target class picker for the New Reference dialog (shared component via TSM service) -->
+    <component
+      :is="ClassPickerDialog"
+      v-if="ClassPickerDialog"
+      v-model:visible="showReferenceClassPicker"
+      header="Select Target Class"
+      :source-packages="metamodelerRootPackages"
+      @select="handleReferenceTargetSelect"
+    />
 
     <!-- New Enum Literal Dialog -->
     <Dialog
@@ -715,6 +754,8 @@ async function exportJsonSchema() {
   align-items: center;
   gap: 0.5rem;
   padding: 0.25rem 0;
+  /* Fill the row so right-clicks anywhere in the line open the context menu. */
+  width: 100%;
 }
 
 .tree-node.is-abstract .node-label,
@@ -803,6 +844,27 @@ async function exportJsonSchema() {
   gap: 0.5rem;
 }
 
+.target-type-picker {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--p-inputtext-border-color, var(--surface-border));
+  border-radius: var(--p-inputtext-border-radius, 4px);
+}
+
+.target-type-value {
+  color: var(--text-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.target-type-value.placeholder {
+  color: var(--text-color-secondary, #888);
+}
+
 .w-full {
   width: 100%;
 }
@@ -886,5 +948,9 @@ async function exportJsonSchema() {
 
 :deep(.p-tree-node-label) {
   font-size: 0.875rem;
+  /* Stretch the label wrapper across the row so the .tree-node context-menu
+     target covers the full width, not just the icon + text. */
+  flex: 1 1 auto;
+  min-width: 0;
 }
 </style>

--- a/packages/metamodeler/src/composables/useMetamodeler.ts
+++ b/packages/metamodeler/src/composables/useMetamodeler.ts
@@ -1656,6 +1656,7 @@ export function useMetamodeler() {
     // State
     resource,
     rootPackage,
+    version, // bumped on every model mutation; depend on it to react to edits
     selectedElement,
     dirty,
     filePath,

--- a/packages/storage-core/vite.tsm.config.ts
+++ b/packages/storage-core/vite.tsm.config.ts
@@ -6,8 +6,12 @@
  */
 import { defineConfig } from 'vite'
 import { resolve } from 'path'
+import { tsmPlugin } from '@eclipse-daanse/tsm/vite'
 
 export default defineConfig({
+  plugins: [
+    tsmPlugin({ sharedModules: ['@eclipse-daanse/tsm'] })
+  ],
   build: {
     target: 'esnext',
     minify: false,

--- a/packages/tsm.shared.ts
+++ b/packages/tsm.shared.ts
@@ -1,0 +1,38 @@
+/**
+ * TSM Shared Modules Configuration
+ *
+ * Defines which modules are shared between plugins.
+ * Imports of these modules are rewritten to URLs so the browser caches them.
+ */
+
+// Shared modules - these are loaded once and shared via browser ES module cache
+export const sharedModules = [
+  'storage-core',
+  'storage-model',
+] as const
+
+// Map module names to their plugin URLs
+export const sharedModulePaths: Record<string, string> = {
+  'storage-core': '/plugins/@storage/core/index.js',
+  'storage-model': '/plugins/@storage/model/index.js',
+}
+
+// For dev mode - map to source files (Vite transforms them)
+export const sharedModulePathsDev: Record<string, string> = {
+  'storage-core': '/packages/storage/core/src/index.ts',
+  'storage-model': '/packages/storage/model/src/generated/storage/index.ts',
+}
+
+/**
+ * Get Rollup external config for shared modules
+ */
+export function getExternals(): string[] {
+  return [...sharedModules]
+}
+
+/**
+ * Get Rollup output.paths config for production builds
+ */
+export function getOutputPaths(): Record<string, string> {
+  return { ...sharedModulePaths }
+}

--- a/packages/ui-actions/src/builtinHandlers.ts
+++ b/packages/ui-actions/src/builtinHandlers.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ActionHandler, HandlerContext, ActionResult } from './types'
+import { XMIResource } from '@emfts/core'
 
 /** Export selected object as XMI string */
 export const exportXmiHandler: ActionHandler = {
@@ -14,7 +15,6 @@ export const exportXmiHandler: ActionHandler = {
 
     try {
       // Use emfts serializer
-      const { XMIResource } = await import('@emfts/core')
       const resource = new XMIResource()
       resource.getContents().push(obj)
       const xmiContent = resource.saveToString()

--- a/packages/ui-actions/src/index.ts
+++ b/packages/ui-actions/src/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ModuleContext } from '@eclipse-daanse/tsm'
+import { EPackageRegistry } from '@emfts/core'
 import { markRaw, watch, defineComponent, h, computed } from 'tsm:vue'
 import { ActionRegistryImpl } from './ActionRegistry'
 import { ActionManagerImpl } from './ActionManager'
@@ -58,8 +59,7 @@ export async function activate(context: ModuleContext): Promise<void> {
   // Register EPackages for XMI parsing
   initActionApiPackage()
   // Register ActionsPluginConfig EPackage so xsi:type resolves in config.xmi
-  const { EPackageRegistry } = await import('@emfts/core')
-  EPackageRegistry.INSTANCE.set(ActionsPluginPackage.eNS_URI, ActionsPluginPackage.eINSTANCE)
+EPackageRegistry.INSTANCE.set(ActionsPluginPackage.eNS_URI, ActionsPluginPackage.eINSTANCE)
 
   // Bind core services via DI
   context.services.bindClass('gene.action.registry', ActionRegistryImpl)

--- a/packages/ui-model-browser/src/components/ClassPickerDialog.vue
+++ b/packages/ui-model-browser/src/components/ClassPickerDialog.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch } from 'tsm:vue'
 import { Dialog, Tree } from 'tsm:primevue'
 import { useSharedModelRegistry } from '../composables/useModelRegistry'
+import { deriveRootEPackages, collectClassesDeep, type PickerClass } from './classPickerSource'
 
 interface ClassSelection {
   eClass: any
@@ -10,14 +11,7 @@ interface ClassSelection {
   packageNsURI: string
 }
 
-interface FlatItem {
-  eClass: any
-  qualifiedName: string
-  className: string
-  packageNsURI: string
-  packageName: string
-  isAbstract: boolean
-}
+type FlatItem = PickerClass
 
 const props = withDefaults(defineProps<{
   visible: boolean
@@ -25,6 +19,13 @@ const props = withDefaults(defineProps<{
   /** 'list' = flache Liste (default), 'tree' = Paket-Baum mit Expand/Collapse */
   viewMode?: 'list' | 'tree'
   includeAbstract?: boolean
+  /**
+   * Root EPackage(s) to pick from. When provided, the dialog reads classes from
+   * these (and their subpackages) instead of the shared ModelRegistry. Callers
+   * that edit a live model (e.g. the Metamodeler) pass their working model here
+   * so unsaved/newly added classes are visible. Omit to use the registry.
+   */
+  sourcePackages?: any[]
 }>(), {
   header: 'Select Class',
   viewMode: 'tree',
@@ -41,33 +42,14 @@ const expandedKeys = ref<Record<string, boolean>>({})
 
 // ── Flat list ──────────────────────────────────────────────────────────────
 
-function collectClasses(pkg: any, pkgLabel: string): FlatItem[] {
-  const nsURI = pkg.getNsURI?.() || ''
-  const result: FlatItem[] = []
-  for (const cls of Array.from(pkg.getEClassifiers?.() ?? []) as any[]) {
-    if (!('getEAllAttributes' in cls || 'getEAttributes' in cls)) continue
-    const name = cls.getName?.() || ''
-    if (!name) continue
-    const isAbstract = cls.isAbstract?.() || false
-    if (!props.includeAbstract && isAbstract) continue
-    result.push({
-      eClass: cls,
-      qualifiedName: nsURI ? `${nsURI}#//${name}` : `${pkgLabel}.${name}`,
-      className: name,
-      packageNsURI: nsURI,
-      packageName: pkgLabel,
-      isAbstract
-    })
-  }
-  for (const sub of Array.from(pkg.getESubpackages?.() ?? []) as any[]) {
-    result.push(...collectClasses(sub, `${pkgLabel}.${sub.getName?.() || ''}`))
-  }
-  return result
-}
+// Root EPackages to render (sourcePackages override / registry dedup). See
+// classPickerSource for the rationale; kept pure there so it is unit-testable.
+const rootEPackages = computed<any[]>(() =>
+  deriveRootEPackages(modelRegistry.userPackages?.value, props.sourcePackages)
+)
 
 const flatItems = computed<FlatItem[]>(() =>
-  (modelRegistry.userPackages?.value ?? [])
-    .flatMap((p: any) => collectClasses(p.ePackage, p.ePackage.getName?.() || ''))
+  collectClassesDeep(rootEPackages.value, props.includeAbstract)
 )
 
 // ── Tree nodes (Package als expandierbarer Elternknoten) ───────────────────
@@ -115,8 +97,8 @@ function buildPackageNode(pkg: any, parentPrefix: string): any | null {
 }
 
 const treeNodes = computed(() =>
-  (modelRegistry.userPackages?.value ?? [])
-    .map((p: any) => buildPackageNode(p.ePackage, ''))
+  rootEPackages.value
+    .map((pkg: any) => buildPackageNode(pkg, ''))
     .filter(Boolean)
 )
 

--- a/packages/ui-model-browser/src/components/__tests__/classPickerSource.spec.ts
+++ b/packages/ui-model-browser/src/components/__tests__/classPickerSource.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import { deriveRootEPackages, collectClassesDeep } from '../classPickerSource'
+
+// ── Duck-typed EMF mocks ─────────────────────────────────────────────────────
+
+function eclass(name: string, opts: { abstract?: boolean } = {}) {
+  return {
+    getName: () => name,
+    isAbstract: () => !!opts.abstract,
+    // presence of an attribute accessor marks this as an EClass for the collector
+    getEAttributes: () => []
+  }
+}
+
+// An EDataType-like classifier: no attribute accessors → must be ignored.
+function edatatype(name: string) {
+  return { getName: () => name, getInstanceClassName: () => 'java.lang.String' }
+}
+
+function epackage(
+  name: string,
+  opts: { nsURI?: string; classes?: any[]; subs?: any[] } = {}
+): any {
+  const pkg: any = {
+    getName: () => name,
+    getNsURI: () => opts.nsURI ?? '',
+    getEClassifiers: () => opts.classes ?? [],
+    getESubpackages: () => opts.subs ?? [],
+    getESuperPackage: () => pkg.__super ?? null,
+    __super: null
+  }
+  for (const s of opts.subs ?? []) s.__super = pkg
+  return pkg
+}
+
+const entry = (ePackage: any) => ({ ePackage })
+
+// A waterpark-like model: classes live only in deeply nested subpackages.
+function waterparkModel() {
+  const base = epackage('base', { nsURI: 'wp/thing/base', classes: [eclass('Thing', { abstract: true })] })
+  const geolocation = epackage('geolocation', { nsURI: 'wp/thing/service/geo', classes: [eclass('geometry')] })
+  const service = epackage('service', { nsURI: 'wp/thing/service', subs: [geolocation] })
+  const thing = epackage('thing', { nsURI: 'wp/thing', subs: [base, service] })
+  const event = epackage('event', { nsURI: 'wp/event' })
+  const waterpark = epackage('waterpark', { nsURI: 'wp', subs: [event, thing] })
+  // The registry flattens every subpackage into its own entry alongside the root.
+  const registry = [waterpark, event, thing, base, service, geolocation].map(entry)
+  return { waterpark, base, geolocation, registry }
+}
+
+describe('deriveRootEPackages', () => {
+  it('keeps only root packages from the registry (subpackages are reached via recursion)', () => {
+    const { waterpark, registry } = waterparkModel()
+    const roots = deriveRootEPackages(registry)
+    expect(roots).toEqual([waterpark])
+  })
+
+  it('treats a package whose super is not listed as a root (orphan subpackage)', () => {
+    const orphanParent = epackage('parent', { nsURI: 'p' })
+    const child = epackage('child', { nsURI: 'p/child' })
+    child.__super = orphanParent // parent exists but is NOT a registry entry
+    const roots = deriveRootEPackages([entry(child)])
+    expect(roots).toEqual([child])
+  })
+
+  it('uses sourcePackages verbatim and ignores the registry when provided', () => {
+    const { registry } = waterparkModel()
+    const live = epackage('live', { nsURI: 'live' })
+    expect(deriveRootEPackages(registry, [live])).toEqual([live])
+  })
+
+  it('falls back to the registry when sourcePackages is empty or undefined', () => {
+    const { waterpark, registry } = waterparkModel()
+    expect(deriveRootEPackages(registry, [])).toEqual([waterpark])
+    expect(deriveRootEPackages(registry, undefined)).toEqual([waterpark])
+  })
+
+  it('returns [] for an empty/undefined registry', () => {
+    expect(deriveRootEPackages([])).toEqual([])
+    expect(deriveRootEPackages(undefined)).toEqual([])
+  })
+})
+
+describe('collectClassesDeep', () => {
+  it('collects classes from nested subpackages, each exactly once (no duplicates)', () => {
+    const { waterpark } = waterparkModel()
+    const names = collectClassesDeep([waterpark]).map((c) => c.className).sort()
+    expect(names).toEqual(['Thing', 'geometry'])
+  })
+
+  it('end-to-end with the flattened registry yields each subpackage class once', () => {
+    // Regression: before the dedup fix every subpackage was also a top-level entry,
+    // so classes appeared once per ancestor level.
+    const { registry } = waterparkModel()
+    const names = collectClassesDeep(deriveRootEPackages(registry)).map((c) => c.className).sort()
+    expect(names).toEqual(['Thing', 'geometry'])
+  })
+
+  it('includes classes added to a live source model (sourcePackages path)', () => {
+    // Regression: the picker previously read a stale registry copy and missed
+    // classes created during the editing session.
+    const defect = epackage('defect', { nsURI: 'wp/thing/service/defect', classes: [eclass('abc')] })
+    const service = epackage('service', { nsURI: 'wp/thing/service', subs: [defect] })
+    const thing = epackage('thing', { nsURI: 'wp/thing', subs: [service] })
+    const liveRoot = epackage('waterpark', { nsURI: 'wp', subs: [thing] })
+    const names = collectClassesDeep([liveRoot]).map((c) => c.className)
+    expect(names).toContain('abc')
+  })
+
+  it('excludes abstract classes when includeAbstract is false', () => {
+    const { waterpark } = waterparkModel()
+    const names = collectClassesDeep([waterpark], false).map((c) => c.className)
+    expect(names).toEqual(['geometry']) // Thing is abstract
+  })
+
+  it('ignores non-class classifiers such as EDataTypes', () => {
+    const pkg = epackage('p', { nsURI: 'p', classes: [eclass('Real'), edatatype('EString')] })
+    const names = collectClassesDeep([pkg]).map((c) => c.className)
+    expect(names).toEqual(['Real'])
+  })
+
+  it('builds an EMF-style qualifiedName from the package nsURI', () => {
+    const pkg = epackage('p', { nsURI: 'http://x/p', classes: [eclass('Foo')] })
+    expect(collectClassesDeep([pkg])[0].qualifiedName).toBe('http://x/p#//Foo')
+  })
+})

--- a/packages/ui-model-browser/src/components/classPickerSource.ts
+++ b/packages/ui-model-browser/src/components/classPickerSource.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure, framework-free source resolution for ClassPickerDialog.
+ *
+ * Extracted from the component so the dedup / sourcePackages / subpackage-recursion
+ * logic is unit-testable without mounting Vue or PrimeVue. Operates on duck-typed
+ * EPackage/EClass objects (getNsURI/getName/getEClassifiers/getESubpackages/
+ * getESuperPackage/isAbstract), so tests can pass plain mocks.
+ */
+
+export interface PickerClass {
+  eClass: any
+  qualifiedName: string
+  className: string
+  packageNsURI: string
+  packageName: string
+  isAbstract: boolean
+}
+
+/** A registry entry as exposed by useSharedModelRegistry().userPackages. */
+export interface RegistryPackage {
+  ePackage: any
+}
+
+/**
+ * Decide which root EPackages to render classes from.
+ *
+ * - With an explicit `sourcePackages` (caller owns the hierarchy, e.g. a live model),
+ *   use those as-is.
+ * - Otherwise derive roots from the registry entries: the registry lists every
+ *   subpackage as its own entry in addition to its parent, and callers recurse into
+ *   subpackages themselves — so keep only packages whose super package is not itself
+ *   a listed entry, to avoid emitting each class once per ancestor level.
+ */
+export function deriveRootEPackages(
+  registryPackages: RegistryPackage[] | undefined,
+  sourcePackages?: any[]
+): any[] {
+  if (sourcePackages && sourcePackages.length) return sourcePackages
+  const pkgs = registryPackages ?? []
+  const listed = new Set(pkgs.map((p) => p.ePackage))
+  return pkgs
+    .filter((p) => {
+      const sup = p.ePackage?.getESuperPackage?.()
+      return !sup || !listed.has(sup)
+    })
+    .map((p) => p.ePackage)
+}
+
+/**
+ * Recursively collect EClasses from the given root EPackages and all their subpackages.
+ * Mirrors the dialog's display rules: only classifiers that look like EClasses
+ * (have attribute accessors), named, and abstract ones filtered out when requested.
+ */
+export function collectClassesDeep(rootEPackages: any[], includeAbstract = true): PickerClass[] {
+  const result: PickerClass[] = []
+  const visit = (pkg: any, pkgLabel: string) => {
+    const nsURI = pkg.getNsURI?.() || ''
+    for (const cls of Array.from(pkg.getEClassifiers?.() ?? []) as any[]) {
+      if (!('getEAllAttributes' in cls || 'getEAttributes' in cls)) continue
+      const name = cls.getName?.() || ''
+      if (!name) continue
+      const isAbstract = cls.isAbstract?.() || false
+      if (!includeAbstract && isAbstract) continue
+      result.push({
+        eClass: cls,
+        qualifiedName: nsURI ? `${nsURI}#//${name}` : `${pkgLabel}.${name}`,
+        className: name,
+        packageNsURI: nsURI,
+        packageName: pkgLabel,
+        isAbstract
+      })
+    }
+    for (const sub of Array.from(pkg.getESubpackages?.() ?? []) as any[]) {
+      visit(sub, `${pkgLabel}.${sub.getName?.() || ''}`)
+    }
+  }
+  rootEPackages.forEach((p) => visit(p, p.getName?.() || ''))
+  return result
+}

--- a/packages/ui-model-browser/src/composables/useModelRegistry.ts
+++ b/packages/ui-model-browser/src/composables/useModelRegistry.ts
@@ -517,26 +517,35 @@ export function useModelRegistry() {
   }
 
   /**
-   * Get all classes (including abstract) from a package
+   * Get all classes (including abstract) from a package and its subpackages.
+   * Recurses into nested subpackages so callers that select a parent package
+   * (e.g. the Transformation editor) still see classes that live deeper in the
+   * hierarchy. qualifiedName uses each class's own containing-package prefix.
    */
   function getAllClasses(packageInfo: ModelPackageInfo): ClassInfo[] {
-    const classifiers = packageInfo.ePackage.getEClassifiers()
     const result: ClassInfo[] = []
 
-    for (const classifier of classifiers) {
-      if (isEClass(classifier)) {
-        const eClass = classifier as EClass
-        result.push({
-          qualifiedName: `${packageInfo.nsPrefix}:${eClass.getName()}`,
-          name: eClass.getName(),
-          isAbstract: eClass.isAbstract(),
-          isInterface: eClass.isInterface(),
-          eClass,
-          packageInfo
-        })
+    const visit = (ePackage: EPackage) => {
+      const nsPrefix = ePackage.getNsPrefix?.() || packageInfo.nsPrefix
+      for (const classifier of ePackage.getEClassifiers?.() ?? []) {
+        if (isEClass(classifier)) {
+          const eClass = classifier as EClass
+          result.push({
+            qualifiedName: `${nsPrefix}:${eClass.getName()}`,
+            name: eClass.getName(),
+            isAbstract: eClass.isAbstract(),
+            isInterface: eClass.isInterface(),
+            eClass,
+            packageInfo
+          })
+        }
+      }
+      for (const subPkg of ePackage.getESubpackages?.() ?? []) {
+        visit(subPkg)
       }
     }
 
+    visit(packageInfo.ePackage)
     return result.sort((a, b) => a.name.localeCompare(b.name))
   }
 

--- a/packages/ui-perspectives/src/registry/PerspectiveRegistry.ts
+++ b/packages/ui-perspectives/src/registry/PerspectiveRegistry.ts
@@ -183,6 +183,11 @@ export class PerspectiveManagerImpl implements PerspectiveManager {
       }
     }
 
+    // Notify perspective-aware UI (e.g. the MenuBar toolbar) to reload its menu.
+    // Mirrors setCurrentPerspectiveId(); without this, switches routed through
+    // switchTo() (workspace open, composable, "Edit Metamodel") left the toolbar stale.
+    this.eventBus?.emit?.('gene:menu-changed')
+
     console.log(`[PerspectiveManager] Switched to perspective: ${perspectiveId}`)
   }
 

--- a/packages/ui-perspectives/src/registry/__tests__/PerspectiveRegistry.spec.ts
+++ b/packages/ui-perspectives/src/registry/__tests__/PerspectiveRegistry.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PerspectiveManagerImpl } from '../PerspectiveRegistry'
+
+function makeManager() {
+  const emit = vi.fn()
+  const eventBus = { emit, on: vi.fn(), off: vi.fn() }
+  const panelRegistry: any = { getForPerspective: () => [], register: vi.fn() }
+  const activityRegistry: any = { register: vi.fn() }
+  const mgr = new PerspectiveManagerImpl(panelRegistry, activityRegistry, eventBus)
+  return { mgr, emit }
+}
+
+function perspective(over: Record<string, any> = {}) {
+  return {
+    id: 'metamodeler',
+    name: 'Metamodeler',
+    defaultLayout: { left: [], center: [], right: [], bottom: [] },
+    defaultVisibility: { left: true, right: true, bottom: false },
+    ...over
+  } as any
+}
+
+describe('PerspectiveManagerImpl', () => {
+  it('switchTo updates the current id and emits gene:menu-changed (so the MenuBar reloads)', async () => {
+    const { mgr, emit } = makeManager()
+    mgr.registry.register(perspective())
+
+    await mgr.switchTo('metamodeler')
+
+    expect(mgr.state.currentPerspectiveId).toBe('metamodeler')
+    expect(emit).toHaveBeenCalledWith('gene:menu-changed')
+  })
+
+  it('setCurrentPerspectiveId also emits gene:menu-changed', () => {
+    const { mgr, emit } = makeManager()
+    mgr.registry.register(perspective())
+
+    mgr.setCurrentPerspectiveId('metamodeler')
+
+    expect(mgr.state.currentPerspectiveId).toBe('metamodeler')
+    expect(emit).toHaveBeenCalledWith('gene:menu-changed')
+  })
+
+  it('does not switch nor emit when a workspace-only perspective is activated without a workspace', async () => {
+    const { mgr, emit } = makeManager()
+    mgr.registry.register(perspective({ requiresWorkspace: true }))
+
+    await mgr.switchTo('metamodeler')
+
+    expect(mgr.state.currentPerspectiveId).toBeNull()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('switches to a workspace-only perspective once a workspace is open', async () => {
+    const { mgr, emit } = makeManager()
+    mgr.registry.register(perspective({ requiresWorkspace: true }))
+
+    mgr.setWorkspace({}, '/ws/Waterpark.wsp')
+    await mgr.switchTo('metamodeler')
+
+    expect(mgr.state.currentPerspectiveId).toBe('metamodeler')
+    expect(emit).toHaveBeenCalledWith('gene:menu-changed')
+  })
+
+  it('ignores switchTo for an unknown perspective', async () => {
+    const { mgr, emit } = makeManager()
+
+    await mgr.switchTo('does-not-exist')
+
+    expect(mgr.state.currentPerspectiveId).toBeNull()
+    expect(emit).not.toHaveBeenCalled()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: 'jsdom',
+      setupFiles: ['./vitest.setup.ts'],
       exclude: [...configDefaults.exclude, 'e2e/**'],
       root: fileURLToPath(new URL('./', import.meta.url)),
     },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,19 @@
+/**
+ * Vitest global setup.
+ *
+ * The TSM Vite plugin rewrites `import { x } from 'tsm:mod'` into
+ * `const { x } = __tsm__.require('mod')`. In the running app the TSM runtime
+ * installs `window.__tsm__`; in tests it isn't bootstrapped, so modules that use
+ * `tsm:*` imports throw "__tsm__ is not defined" on import. Provide a minimal
+ * global that resolves the shared libraries we test against to their real packages.
+ */
+import * as vue from 'vue'
+
+const sharedModules: Record<string, any> = {
+  vue,
+}
+
+;(globalThis as any).__tsm__ = {
+  require: (id: string) => sharedModules[id] ?? {},
+  register: () => {},
+}


### PR DESCRIPTION
Integriert den gesammelten Stand von `fix/prod-build-vite6` nach `main`. Der Merge ist konfliktfrei (die Vite-Build-Fixes liegen bereits inhaltsgleich auf `main`).

## Enthaltene Arbeit
- **Production-Build / Vite 5→6** Regressionen behoben (`tsm.shared.ts`, generierte ActionApi-Klassen u. a.).
- **Modularität:** ClassPickerDialog wird in cocl-editor / data-generator / metamodeler über die TSM-Service-Registry bezogen (kein statischer `ui-model-browser`-Import) → `tsm-module-dependencies` grün.
- **Metamodeler/Transformation (PR #56):**
  - ClassPickerDialog: Dedup (nur von Wurzelpaketen rekursieren) + Prop `sourcePackages` (live editiertes Modell als Quelle); reine Logik in `classPickerSource.ts`.
  - „New Reference"-Zielauswahl nutzt das Live-Modell (neu angelegte/verschachtelte Klassen sichtbar, version-reaktiv); Kontextmenü-Trefferfläche auf volle Zeilenbreite.
  - `ModelRegistry.getAllClasses` rekursiert über Subpackages → Transformation-Editor zeigt Klassen aus tief verschachtelten Paketen.
  - Menü-Toolbar: `PerspectiveRegistry.switchTo` emittiert `gene:menu-changed`; `App.handleMetamodelEdit` holt Composables bei Bedarf.
  - Tests: `classPickerSource`, `PerspectiveRegistry`; `vitest.setup.ts` für `tsm:`-Imports. Gesamte Suite 146/146 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)